### PR TITLE
Fix host and port parameter format for wait-for-it.sh

### DIFF
--- a/scalardb-server-sample/docker-compose-cassandra.yml
+++ b/scalardb-server-sample/docker-compose-cassandra.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "60051:60051" # scalardb-server port
     entrypoint: /bin/bash
-    command: ./wait-for-it.sh -t 60 tcp://cassandra:9042 -- ./bin/scalardb-server --config database.properties
+    command: ./wait-for-it.sh -t 60 cassandra:9042 -- ./bin/scalardb-server --config database.properties
     networks:
       - scalar-network
 networks:


### PR DESCRIPTION
I think the correct host and port parameter format for `wait-for-it.sh` is `host:port`, but we specify `tcp://cassandra:9042` in `scalardb-server-sample/docker-compose-cassandra.yml`.  This PR fixes this. Please take a look!