### PR TITLE
Update Microservice Transaction Sample

### DIFF
--- a/microservice-transaction-sample/build.gradle
+++ b/microservice-transaction-sample/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     ext {
         grpcVersion = '1.38.0'
         protocVersion = '3.17.2'
-        scalarDbVersion = '3.2.0'
+        scalarDbVersion = '3.4.1'
         picoCliVersion = '4.1.4'
         protobufJavaFormatVersion = '1.4'
         log4jVersion = '2.14.1'

--- a/microservice-transaction-sample/customer-service-schema-loader/Dockerfile
+++ b/microservice-transaction-sample/customer-service-schema-loader/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.2.0
+FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.4.1
 COPY customer-service-schema.json schema.json
 ENTRYPOINT ["java", "-jar", "app.jar", "-f", "schema.json"]
 

--- a/microservice-transaction-sample/order-service-schema-loader/Dockerfile
+++ b/microservice-transaction-sample/order-service-schema-loader/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.2.0
+FROM ghcr.io/scalar-labs/scalardb-schema-loader:3.4.1
 COPY order-service-schema.json schema.json
 ENTRYPOINT ["java", "-jar", "app.jar", "-f", "schema.json"]


### PR DESCRIPTION
This PR upgrades the Scalar DB version to `3.4.1` for Microservice Transaction Sample. Please take a look!