### PR TITLE
Rename `updatedCreditLimit` to `updatedCreditTotal`

### DIFF
--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -127,10 +127,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
         return;
       }
 
-      int updatedCreditLimit = result.get().creditTotal - request.getAmount();
+      int updatedCreditTotal = result.get().creditTotal - request.getAmount();
 
       // Check if over repayment or not
-      if (updatedCreditLimit < 0) {
+      if (updatedCreditTotal < 0) {
         abortTransaction(transaction);
         responseObserver.onError(
             Status.FAILED_PRECONDITION.withDescription("Over repayment").asRuntimeException());
@@ -138,7 +138,7 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
       }
 
       // Reduce credit_total for the customer
-      Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditLimit);
+      Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
 
       // Commit the transaction (even when the transaction is read-only, we need to commit)
       transaction.commit();

--- a/multi-storage-transaction-sample/src/main/java/sample/Sample.java
+++ b/multi-storage-transaction-sample/src/main/java/sample/Sample.java
@@ -381,10 +381,10 @@ public class Sample implements AutoCloseable {
         throw new RuntimeException("Customer not found");
       }
 
-      int updatedCreditLimit = customer.get().getInt("credit_total") - amount;
+      int updatedCreditTotal = customer.get().getInt("credit_total") - amount;
 
       // Check if over repayment or not
-      if (updatedCreditLimit < 0) {
+      if (updatedCreditTotal < 0) {
         throw new RuntimeException("Over repayment");
       }
 
@@ -394,7 +394,7 @@ public class Sample implements AutoCloseable {
               .namespace("customer")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
-              .intValue("credit_total", updatedCreditLimit)
+              .intValue("credit_total", updatedCreditTotal)
               .build());
 
       // Commit the transaction

--- a/scalardb-sample/src/main/java/sample/Sample.java
+++ b/scalardb-sample/src/main/java/sample/Sample.java
@@ -380,10 +380,10 @@ public class Sample implements AutoCloseable {
         throw new RuntimeException("Customer not found");
       }
 
-      int updatedCreditLimit = customer.get().getInt("credit_total") - amount;
+      int updatedCreditTotal = customer.get().getInt("credit_total") - amount;
 
       // Check if over repayment or not
-      if (updatedCreditLimit < 0) {
+      if (updatedCreditTotal < 0) {
         throw new RuntimeException("Over repayment");
       }
 
@@ -393,7 +393,7 @@ public class Sample implements AutoCloseable {
               .namespace("sample")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
-              .intValue("credit_total", updatedCreditLimit)
+              .intValue("credit_total", updatedCreditTotal)
               .build());
 
       // Commit the transaction


### PR DESCRIPTION
Noticed some ScalarDB sample projects use variable name `updatedCreditLimit`, but `updatedCreditTotal` seems better.