### PR TITLE
Use new high-level 2PC API in the sample application for microservice with Spring Data JDBC for ScalarDB

### DIFF
--- a/spring-data-microservice-transaction-sample/build.gradle
+++ b/spring-data-microservice-transaction-sample/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     ext {
         grpcVersion = '1.53.0'
         protocVersion = '3.23.1'
-        scalarDbVersion = '3.9.0'
+        scalarDbVersion = '3.9.1'
         picoCliVersion = '4.7.1'
         protobufJavaFormatVersion = '1.4'
         slf4jVersion = '2.0.7'

--- a/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -72,7 +72,6 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
         }));
   }
 
-  // TODO: Try @Transactional
   @Override
   public void repayment(RepaymentRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Repayment", () ->

--- a/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/domain/repository/CustomerRepository.java
+++ b/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/domain/repository/CustomerRepository.java
@@ -1,7 +1,6 @@
 package sample.customer.domain.repository;
 
 import com.scalar.db.sql.springdata.twopc.ScalarDbTwoPcRepository;
-import java.util.function.Supplier;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import sample.customer.domain.model.Customer;
@@ -14,18 +13,5 @@ public interface CustomerRepository extends ScalarDbTwoPcRepository<Customer, In
     if (!findById(customer.customerId).isPresent()) {
       insert(customer);
     }
-  }
-
-  default <T> T execOneshotOperation(Supplier<T> task) {
-    begin();
-    T result = task.get();
-    prepare();
-    validate();
-    commit();
-    return result;
-  }
-
-  default <T> T execBatchOperations(Supplier<T> task) {
-    return task.get();
   }
 }

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/domain/repository/ItemRepository.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/domain/repository/ItemRepository.java
@@ -1,7 +1,6 @@
 package sample.order.domain.repository;
 
 import com.scalar.db.sql.springdata.twopc.ScalarDbTwoPcRepository;
-import java.util.function.Supplier;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import sample.order.domain.model.Item;

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/domain/repository/OrderRepository.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/domain/repository/OrderRepository.java
@@ -2,7 +2,6 @@ package sample.order.domain.repository;
 
 import com.scalar.db.sql.springdata.twopc.ScalarDbTwoPcRepository;
 import java.util.List;
-import java.util.function.Supplier;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import sample.order.domain.model.Order;
@@ -12,13 +11,4 @@ import sample.order.domain.model.Order;
 public interface OrderRepository extends ScalarDbTwoPcRepository<Order, String> {
 
   List<Order> findAllByCustomerIdOrderByTimestampDesc(int customerId);
-
-  default <T> T execOneshotOperation(Supplier<T> task) {
-    begin();
-    T result = task.get();
-    prepare();
-    validate();
-    commit();
-    return result;
-  }
 }


### PR DESCRIPTION
## Context

We've merged [Add some high-level 2PC API for participants](https://github.com/scalar-labs/scalardb-sql/pull/210) and released it as `3.9.1`. The new APIs are useful and should be introduced in the sample application.

## Changes

This PR update `spring-data-microservice-transaction-sample` to use the new high-level 2PC APIs.