### PR TITLE
Use ScalarDB 3.9.1

### DIFF
--- a/microservice-transaction-sample/build.gradle
+++ b/microservice-transaction-sample/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     ext {
         grpcVersion = '1.53.0'
         protocVersion = '3.23.1'
-        scalarDbVersion = '3.9.0'
+        scalarDbVersion = '3.9.1'
         picoCliVersion = '4.7.1'
         protobufJavaFormatVersion = '1.4'
         log4jVersion = '2.20.0'

--- a/multi-storage-transaction-sample/build.gradle
+++ b/multi-storage-transaction-sample/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.0'
+    implementation 'com.scalar-labs:scalardb:3.9.1'
     implementation 'info.picocli:picocli:4.7.1'
 }
 

--- a/scalardb-sample/build.gradle
+++ b/scalardb-sample/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.0'
+    implementation 'com.scalar-labs:scalardb:3.9.1'
     implementation 'info.picocli:picocli:4.7.1'
 }
 

--- a/scalardb-server-sample/build.gradle
+++ b/scalardb-server-sample/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.9.0'
+    implementation 'com.scalar-labs:scalardb:3.9.1'
 }
 
 application {

--- a/scalardb-sql-jdbc-sample/build.gradle
+++ b/scalardb-sql-jdbc-sample/build.gradle
@@ -18,8 +18,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb-sql-jdbc:3.9.0'
-    implementation 'com.scalar-labs:scalardb-sql-direct-mode:3.9.0'
+    implementation 'com.scalar-labs:scalardb-sql-jdbc:3.9.1'
+    implementation 'com.scalar-labs:scalardb-sql-direct-mode:3.9.1'
     implementation 'info.picocli:picocli:4.7.1'
 }
 

--- a/spring-data-multi-storage-transaction-sample/build.gradle
+++ b/spring-data-multi-storage-transaction-sample/build.gradle
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.scalar-labs:scalardb-sql-spring-data:3.9.0"
-    implementation "com.scalar-labs:scalardb-sql-direct-mode:3.9.0"
+    implementation "com.scalar-labs:scalardb-sql-spring-data:3.9.1"
+    implementation "com.scalar-labs:scalardb-sql-direct-mode:3.9.1"
     // This includes dependencies to `spring-boot-starter` and `picocli`
     implementation "info.picocli:picocli-spring-boot-starter:4.7.1"
     // For retry

--- a/spring-data-sample/build.gradle
+++ b/spring-data-sample/build.gradle
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.scalar-labs:scalardb-sql-spring-data:3.9.0"
-    implementation "com.scalar-labs:scalardb-sql-direct-mode:3.9.0"
+    implementation "com.scalar-labs:scalardb-sql-spring-data:3.9.1"
+    implementation "com.scalar-labs:scalardb-sql-direct-mode:3.9.1"
     // This includes dependencies to `spring-boot-starter` and `picocli`
     implementation "info.picocli:picocli-spring-boot-starter:4.7.1"
     // For retry


### PR DESCRIPTION
This PR updates the ScalarDB dependencies in the samples to version `3.9.1`. The update for the microservice sample application with Spring Data JDBC for ScalarDB is already addressed in https://github.com/scalar-labs/scalardb-samples/pull/42, so this PR focuses on the other samples. Please take a look!