### PR TITLE
Improve the usage of @Retryable in the sample applications of Spring Data JDBC for ScalarDB

### DIFF
--- a/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -29,10 +29,6 @@ import sample.rpc.RollbackRequest;
 import sample.rpc.ValidateRequest;
 
 @Service
-@Retryable(
-    include = TransientDataAccessException.class,
-    maxAttempts = 8,
-    backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
 public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase implements
     Closeable {
 
@@ -56,6 +52,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     });
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Override
   public void getCustomerInfo(
       GetCustomerInfoRequest request, StreamObserver<GetCustomerInfoResponse> responseObserver) {
@@ -72,6 +72,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
         }));
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Override
   public void repayment(RepaymentRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Repayment", () ->
@@ -97,6 +101,8 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
         ));
   }
 
+  // @Retryable shouldn't be used here as this is used as a participant API and
+  // will be retried by the coordinator service if needed
   @Override
   public void payment(PaymentRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Payment", () ->
@@ -121,6 +127,8 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
         }));
   }
 
+  // @Retryable shouldn't be put as this is used as a participant API and
+  // will be retried by the coordinator service if needed
   @Override
   public void prepare(PrepareRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Prepare", () -> {
@@ -129,6 +137,8 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     });
   }
 
+  // @Retryable shouldn't be put as this is used as a participant API and
+  // will be retried by the coordinator service if needed
   @Override
   public void validate(ValidateRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Validate", () -> {
@@ -137,6 +147,8 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     });
   }
 
+  // @Retryable shouldn't be put as this is used as a participant API and
+  // will be retried by the coordinator service if needed
   @Override
   public void commit(CommitRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Commit", () -> {
@@ -145,6 +157,8 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     });
   }
 
+  // @Retryable shouldn't be put as this is used as a participant API and
+  // will be retried by the coordinator service if needed
   @Override
   public void rollback(RollbackRequest request, StreamObserver<Empty> responseObserver) {
     execAndReturnResponse(responseObserver, "Rollback", () -> {

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -48,10 +48,6 @@ import sample.rpc.RollbackRequest;
 import sample.rpc.ValidateRequest;
 
 @Service
-@Retryable(
-    include = TransientDataAccessException.class,
-    maxAttempts = 8,
-    backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
 public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implements Closeable {
 
   private static final Logger logger = LoggerFactory.getLogger(OrderService.class);
@@ -93,6 +89,10 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   /**
    * Place an order. It's a transaction that spans OrderService and CustomerService
    */
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Override
   public void placeOrder(
       PlaceOrderRequest request, StreamObserver<PlaceOrderResponse> responseObserver) {
@@ -174,6 +174,10 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   /**
    * Get Order information by order ID
    */
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Override
   public void getOrder(GetOrderRequest request, StreamObserver<GetOrderResponse> responseObserver) {
     execAndReturnResponse(responseObserver, "Getting an order", () ->
@@ -198,6 +202,10 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   /**
    * Get Order information by customer ID
    */
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Override
   public void getOrders(
       GetOrdersRequest request, StreamObserver<GetOrdersResponse> responseObserver) {

--- a/spring-data-multi-storage-transaction-sample/src/main/java/sample/SampleService.java
+++ b/spring-data-multi-storage-transaction-sample/src/main/java/sample/SampleService.java
@@ -28,10 +28,6 @@ import sample.domain.repository.StatementRepository;
 
 @EnableScalarDbRepositories
 @Service
-@Retryable(
-    include = TransientDataAccessException.class,
-    maxAttempts = 8,
-    backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
 public class SampleService {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -60,6 +56,10 @@ public class SampleService {
     }
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getCustomerInfo(int customerId) {
     try {
@@ -71,6 +71,10 @@ public class SampleService {
     }
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String placeOrder(int customerId, List<ItemOrder> itemOrders) {
     String orderId = UUID.randomUUID().toString();
@@ -134,6 +138,10 @@ public class SampleService {
         orderId, customerId, customer.name, order.timestamp, statementDetails, total.get());
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getOrderByOrderId(String orderId) {
     // Get an order JSON for the specified order ID.
@@ -141,6 +149,10 @@ public class SampleService {
     return asJson(getOrderDetail(orderId));
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getOrdersByCustomerId(int customerId) {
     // Retrieve the order info for the customer ID from the orders table.
@@ -151,6 +163,10 @@ public class SampleService {
             .collect(Collectors.toList()));
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public void repayment(int customerId, int amount) {
     Customer customer = customerRepository.getById(customerId);

--- a/spring-data-sample/src/main/java/sample/SampleService.java
+++ b/spring-data-sample/src/main/java/sample/SampleService.java
@@ -28,10 +28,6 @@ import sample.domain.repository.StatementRepository;
 
 @EnableScalarDbRepositories
 @Service
-@Retryable(
-    include = TransientDataAccessException.class,
-    maxAttempts = 8,
-    backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
 public class SampleService {
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -60,6 +56,10 @@ public class SampleService {
     }
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getCustomerInfo(int customerId) {
     try {
@@ -71,6 +71,10 @@ public class SampleService {
     }
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String placeOrder(int customerId, List<ItemOrder> itemOrders) {
     String orderId = UUID.randomUUID().toString();
@@ -134,6 +138,10 @@ public class SampleService {
         orderId, customerId, customer.name, order.timestamp, statementDetails, total.get());
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getOrderByOrderId(String orderId) {
     // Get an order JSON for the specified order ID.
@@ -141,6 +149,10 @@ public class SampleService {
     return asJson(getOrderDetail(orderId));
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public String getOrdersByCustomerId(int customerId) {
     // Retrieve the order info for the customer ID from the orders table.
@@ -151,6 +163,10 @@ public class SampleService {
             .collect(Collectors.toList()));
   }
 
+  @Retryable(
+      include = TransientDataAccessException.class,
+      maxAttempts = 8,
+      backoff = @Backoff(delay = 1000, maxDelay = 8000, multiplier = 2))
   @Transactional
   public void repayment(int customerId, int amount) {
     Customer customer = customerRepository.getById(customerId);


### PR DESCRIPTION
## Context

We noticed the current sample projects does unnecessary retries (e.g., the participant service retries by itself when it fails although the retry should be triggered by the coordinator)

## Changes

This PR replaces the very coarse `@Retryable` annotation for all the methods of a service class with fine-grained annotations on methods to be retried.