### PR TITLE
Change link for "Getting Started with ScalarDB"

### DIFF
--- a/scalardb-server-sample/README.md
+++ b/scalardb-server-sample/README.md
@@ -1,6 +1,6 @@
 # ScalarDB Server Sample
 This is a sample application that uses ScalarDB Server, a gRPC server that implements ScalarDB interface, as a backend.
-For using the native ScalarDB library, please refer to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md).
+For using the native ScalarDB library, please refer to [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md).
 More information about ScalarDB Server can be found [here](https://github.com/scalar-labs/scalardb/tree/master/docs/scalardb-server.md).
 
 ## Sample application
@@ -38,7 +38,7 @@ Please note that we should wait around a bit more than one minute because Scalar
 ```shell
 $ docker-compose -f docker-compose-cassandra.yml up -d
 ```
-*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
+*For using other databases as the backend for ScalarDB Server, we can change the configuration of [database.properties](database.properties) according to [Getting Started with ScalarDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md). After that we can start ScalarDB Server using [docker-compose.yml](docker-compose.yml) instead.*
 
 ### ScalarDB client
 The sample application uses a client that implements ScalarDB interface.


### PR DESCRIPTION
This PR changes the link for the "Getting Started with ScalarDB" doc, which we updated in https://github.com/scalar-labs/scalardb/pull/990. The previous doc no longer exists, so that's why we need to update this link.