### PR TITLE
Revise sample tutorials for multi-storage transactions and microservice transactions

### DIFF
--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -17,9 +17,9 @@ The databases that you will be using in the sample application are Cassandra and
 
 ![Overview](images/overview.png)
 
-As shown in the diagram, both services access a small coordinator database used for the Consensus Commit protocol. The database is service-independent and exists for managing transaction metadata for Consensus Commit in a highly available manner.
+As shown in the diagram, both services access a small Coordinator database used for the Consensus Commit protocol. The database is service-independent and exists for managing transaction metadata for Consensus Commit in a highly available manner.
 
-In the sample application, for ease of setup and explanation, we co-locate the coordinator database in the same Cassandra instance of the Order Service. Alternatively, you can manage the coordinator database as a separate database.
+In the sample application, for ease of setup and explanation, we co-locate the Coordinator database in the same Cassandra instance of the Order Service. Alternatively, you can manage the Coordinator database as a separate database.
 
 {% capture notice--info %}
 **Note**

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of [two-phase commit transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 
@@ -26,7 +26,7 @@ In the sample application, for ease of setup and explanation, we co-locate the c
 
 Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [Handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
 
-Additionally, for the purpose of the sample application, each service has one container so that you can avoid using request routing between the services. However, for production use, because each service typically has multiple servers or hosts for scalability and availability, you should consider request routing between the services in two-phase commit transactions. For details about request routing, see [Request routing in two-phase commit transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#request-routing-in-two-phase-commit-transactions).
+Additionally, for the purpose of the sample application, each service has one container so that you can avoid using request routing between the services. However, for production use, because each service typically has multiple servers or hosts for scalability and availability, you should consider request routing between the services in transactions with a two-phase commit interface. For details about request routing, see [Request routing in transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#request-routing-in-transactions-with-a-two-phase-commit-interface).
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
@@ -380,11 +380,11 @@ The following sequence diagram shows the transaction for placing an order:
 
 ![Microservice transaction sequence diagram](images/sequence_diagram.png)
 
-### 1. Two-phase commit transaction is started
+### 1. Transaction with a two-phase commit interface is started
 
 When a client sends a request to place an order to the Order Service, `OrderService.placeOrder()` is called, and the microservice transaction starts.
 
-At first, the Order Service starts a two-phase commit transaction with `start()` as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+At first, the Order Service starts a transaction with a two-phase commit interface with `start()` as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction = twoPhaseCommitTransactionManager.start();
@@ -392,7 +392,7 @@ transaction = twoPhaseCommitTransactionManager.start();
 
 ### 2. CRUD operations are executed
 
-After the two-phase commit transaction starts, CRUD operations are executed. The Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
+After the transaction with a two-phase commit interface starts, CRUD operations are executed. The Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
 
 ```java
 // Put the order info into the `orders` table.

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -24,7 +24,7 @@ In the sample application, for ease of setup and explanation, we co-locate the c
 {% capture notice--info %}
 **Note**
 
-Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [Handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
+Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [How to handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#how-to-handle-exceptions).
 
 Additionally, for the purpose of the sample application, each service has one container so that you can avoid using request routing between the services. However, for production use, because each service typically has multiple servers or hosts for scalability and availability, you should consider request routing between the services in transactions with a two-phase commit interface. For details about request routing, see [Request routing in transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#request-routing-in-transactions-with-a-two-phase-commit-interface).
 {% endcapture %}
@@ -99,7 +99,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [Configuration](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#configuration).
+Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 
@@ -513,4 +513,4 @@ TwoPhaseCommitTransaction transaction =
 transaction.rollback();
 ```
 
-For details about how to handle exceptions in ScalarDB, see [Handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
+For details about how to handle exceptions in ScalarDB, see [How to handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#how-to-handle-exceptions).

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -137,7 +137,7 @@ To load the schema for [order-service-schema.json](order-service-schema.json) in
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-cassandra.properties --schema-file order-service-schema.json --coordinator
 ```
 
-#### Schema reference
+#### Schema details
 
 As shown in [customer-service-schema.json](customer-service-schema.json) for the sample application, all the tables for the Customer Service are created in the `customer_service` namespace.
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -6,20 +6,20 @@ This tutorial describes how to create a sample application that supports microse
 
 The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of [two-phase commit transactions](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
-The sample application has two microservices called *Customer Service* and *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html).
+The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 
-- **Customer Service** manages customer information, including line-of-credit information, credit limit, and credit total.
-- **Order Service** is responsible for order operations like placing an order and getting order histories.
+- The **Customer Service** manages customer information, including line-of-credit information, credit limit, and credit total.
+- The **Order Service** is responsible for order operations like placing an order and getting order histories.
 
 Each service has gRPC endpoints. Clients call the endpoints, and the services call each endpoint as well.
 
-The databases that you will be using in the sample application are Cassandra and MySQL. Customer Service and Order Service use Cassandra and MySQL, respectively, through ScalarDB.
+The databases that you will be using in the sample application are Cassandra and MySQL. The Customer Service and the Order Service use Cassandra and MySQL, respectively, through ScalarDB.
 
 ![Overview](images/overview.png)
 
 As shown in the diagram, both services access a small coordinator database used for the Consensus Commit protocol. The database is service-independent and exists for managing transaction metadata for Consensus Commit in a highly available manner.
 
-In the sample application, for ease of setup and explanation, we co-locate the coordinator database in the same Cassandra instance of Order Service. Alternatively, you can manage the coordinator database as a separate database.
+In the sample application, for ease of setup and explanation, we co-locate the coordinator database in the same Cassandra instance of the Order Service. Alternatively, you can manage the coordinator database as a separate database.
 
 {% capture notice--info %}
 **Note**
@@ -53,13 +53,13 @@ The endpoints defined in the services are as follows:
 
 The sample application supports the following types of transactions:
 
-- Get customer information through the `getCustomerInfo` endpoint of Customer Service.
-- Place an order by using a line of credit through the `placeOrder` endpoint of Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of Customer Service.
+- Get customer information through the `getCustomerInfo` endpoint of the Customer Service.
+- Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` of Order Service.
-- Get order information by customer ID through the `getOrders` of Order Service.
-- Make a payment through the `repayment` endpoint of Customer Service.
+- Get order information by order ID through the `getOrder` of the Order Service.
+- Get order information by customer ID through the `getOrders` of the Order Service.
+- Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
 ## Prerequisites
@@ -117,7 +117,7 @@ Starting the Docker container may take more than one minute depending on your de
 
 ### Load the schema
 
-The database schema (the method in which the data will be organized) for the sample application has already been defined in [customer-service-schema.json](customer-service-schema.json) for Customer Service and [order-service-schema.json](order-service-schema.json) for Order Service.
+The database schema (the method in which the data will be organized) for the sample application has already been defined in [customer-service-schema.json](customer-service-schema.json) for the Customer Service and [order-service-schema.json](order-service-schema.json) for the Order Service.
 
 To apply the schema, go to the [`scalardb` Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/microservice-transaction-sample` folder.
 
@@ -139,13 +139,13 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-cassandra.pro
 
 #### Schema reference
 
-As shown in [customer-service-schema.json](customer-service-schema.json) for the sample application, all the tables for Customer Service are created in the `customer_service` namespace.
+As shown in [customer-service-schema.json](customer-service-schema.json) for the sample application, all the tables for the Customer Service are created in the `customer_service` namespace.
 
 - `customer_service.customers`: a table that manages customers' information
   - `credit_limit`: the maximum amount of money a lender will allow each customer to spend when using a line of credit
   - `credit_total`: the amount of money that each customer has already spent by using their line of credit
 
-As shown in [order-service-schema.json](order-service-schema.json) for the sample application, all the tables for Order Service are created in the `order_service` namespace.
+As shown in [order-service-schema.json](order-service-schema.json) for the sample application, all the tables for the Order Service are created in the `order_service` namespace.
 
 - `order_service.orders`: a table that manages order information
 - `order_service.statements`: a table that manages order statement information
@@ -374,7 +374,7 @@ $ docker-compose down
 
 ## Reference - How the microservice transaction is achieved
 
-The transaction for placing an order achieves the microservice transaction, so this section focuses on how the transaction that spans Customer Service and Order service is implemented.
+The transaction for placing an order achieves the microservice transaction, so this section focuses on how the transaction that spans the Customer Service and the Order Service is implemented.
 
 The following sequence diagram shows the transaction for placing an order:
 
@@ -382,9 +382,9 @@ The following sequence diagram shows the transaction for placing an order:
 
 ### 1. Two-phase commit transaction is started
 
-When a client sends a request to place an order to Order Service, `OrderService.placeOrder()` is called, and the microservice transaction starts.
+When a client sends a request to place an order to the Order Service, `OrderService.placeOrder()` is called, and the microservice transaction starts.
 
-At first, Order Service starts a two-phase commit transaction with `start()` as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+At first, the Order Service starts a two-phase commit transaction with `start()` as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction = twoPhaseCommitTransactionManager.start();
@@ -392,7 +392,7 @@ transaction = twoPhaseCommitTransactionManager.start();
 
 ### 2. CRUD operations are executed
 
-After the two-phase commit transaction starts, CRUD operations are executed. Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
+After the two-phase commit transaction starts, CRUD operations are executed. The Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
 
 ```java
 // Put the order info into the `orders` table.
@@ -416,7 +416,7 @@ for (ItemOrder itemOrder : request.getItemOrderList()) {
 }
 ```
 
-Then, Order Service calls the `payment` gRPC endpoint of Customer Service along with the transaction ID. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+Then, the Order Service calls the `payment` gRPC endpoint of the Customer Service along with the transaction ID. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
 
 This endpoint first joins the transaction with `join()` as follows. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
 
@@ -427,7 +427,7 @@ twoPhaseCommitTransactionManager.join(request.getTransactionId());
 The endpoint then gets the customer information and checks if the customer's credit total exceeds the credit limit after the payment. If the credit total does not exceed the credit limit, the endpoint updates the customer's credit total. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
-// Join the transaction that Order Service started.
+// Join the transaction that the Order Service started.
 transaction = twoPhaseCommitTransactionManager.join(request.getTransactionId());
 
 // Retrieve the customer info for the customer ID.
@@ -455,16 +455,16 @@ Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTo
 
 ### 3. Transaction is committed by using the two-phase commit protocol
 
-After Order Service receives the update that the payment succeeded, Order Service tries to commit the transaction.
+After the Order Service receives the update that the payment succeeded, the Order Service tries to commit the transaction.
 
-To commit the transaction, Order Service starts with preparing the transaction. Order Service calls `prepare()` from its transaction object and calls the `prepare` gRPC endpoint of Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
+To commit the transaction, the Order Service starts with preparing the transaction. The Order Service calls `prepare()` from its transaction object and calls the `prepare` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
 
 ```java
 transaction.prepare();
 callPrepareEndpoint(transaction.getId());
 ```
 
-In this endpoint, Customer Service resumes the transaction and calls `prepare()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java):
+In this endpoint, the Customer Service resumes the transaction and calls `prepare()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java):
 
 ```java
 // Resume the transaction.
@@ -474,16 +474,16 @@ transaction = twoPhaseCommitTransactionManager.resume(request.getTransactionId()
 transaction.prepare();
 ```
 
-Similarly, Order Service and Customer Service call `validate()` from their transaction objects. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java) and [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java). For details about `validate()`, see [Validate the transaction](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#validate-the-transaction).
+Similarly, the Order Service and the Customer Service call `validate()` from their transaction objects. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java) and [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java). For details about `validate()`, see [Validate the transaction](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#validate-the-transaction).
 
-After preparing and validating the transaction succeeds in both Order Service and Customer Service, the transaction can be committed. In this case, Order Service calls `commit()` from its transaction object and then calls the `commit` gRPC endpoint of Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+After preparing and validating the transaction succeeds in both the Order Service and the Customer Service, the transaction can be committed. In this case, the Order Service calls `commit()` from its transaction object and then calls the `commit` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction.commit();
 callCommitEndpoint(transaction.getId());
 ```
 
-In this endpoint, Customer Service resumes the transaction and calls `commit()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+In this endpoint, the Customer Service resumes the transaction and calls `commit()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 // Resume the transaction.
@@ -495,14 +495,14 @@ transaction.commit();
 
 ### Error handling
 
-If an error happens while executing a transaction, you will need to roll back the transaction. In this case, Order Service calls `rollback()` from its transaction object and then calls the `rollback` gRPC endpoint of Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+If an error happens while executing a transaction, you will need to roll back the transaction. In this case, the Order Service calls `rollback()` from its transaction object and then calls the `rollback` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction.rollback();
 callRollbackEndpoint(transaction.getId());
 ```
 
-In this endpoint, Customer Service resumes the transaction and calls `rollback()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+In this endpoint, the Customer Service resumes the transaction and calls `rollback()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 // Resume the transaction.

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -119,7 +119,7 @@ Starting the Docker container may take more than one minute depending on your de
 
 The database schema (the method in which the data will be organized) for the sample application has already been defined in [customer-service-schema.json](customer-service-schema.json) for the Customer Service and [order-service-schema.json](order-service-schema.json) for the Order Service.
 
-To apply the schema, go to the [`scalardb` Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/microservice-transaction-sample` folder.
+To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/microservice-transaction-sample` folder.
 
 #### MySQL
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports microse
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample) but takes advantage of [transactions with a two-phase commit interface](https://github.com/scalar-labs/scalardb/tree/master/docs/two-phase-commit-transactions.md) when using ScalarDB.
 
 The sample application has two microservices called the *Customer Service* and the *Order Service* based on the [database-per-service pattern](https://microservices.io/patterns/data/database-per-service.html):
 
@@ -99,7 +99,7 @@ $ cd scalardb-samples/microservice-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, run the following command:
 
@@ -117,13 +117,13 @@ Starting the Docker container may take more than one minute depending on your de
 
 ### Load the schema
 
-The database schema (the method in which the data will be organized) for the sample application has already been defined in [customer-service-schema.json](customer-service-schema.json) for the Customer Service and [order-service-schema.json](order-service-schema.json) for the Order Service.
+The database schema (the method in which the data will be organized) for the sample application has already been defined in [`customer-service-schema.json`](customer-service-schema.json) for the Customer Service and [`order-service-schema.json`](order-service-schema.json) for the Order Service.
 
 To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/microservice-transaction-sample` folder.
 
 #### MySQL
 
-To load the schema for [customer-service-schema.json](customer-service-schema.json) into MySQL, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
+To load the schema for [`customer-service-schema.json`](customer-service-schema.json) into MySQL, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
 
 ```console
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-mysql.properties --schema-file customer-service-schema.json
@@ -131,7 +131,7 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-mysql.propert
 
 #### Cassandra
 
-To load the schema for [order-service-schema.json](order-service-schema.json) into Cassandra, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
+To load the schema for [`order-service-schema.json`](order-service-schema.json) into Cassandra, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
 
 ```console
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-cassandra.properties --schema-file order-service-schema.json --coordinator
@@ -139,13 +139,13 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config database-cassandra.pro
 
 #### Schema details
 
-As shown in [customer-service-schema.json](customer-service-schema.json) for the sample application, all the tables for the Customer Service are created in the `customer_service` namespace.
+As shown in [`customer-service-schema.json`](customer-service-schema.json) for the sample application, all the tables for the Customer Service are created in the `customer_service` namespace.
 
 - `customer_service.customers`: a table that manages customers' information
   - `credit_limit`: the maximum amount of money a lender will allow each customer to spend when using a line of credit
   - `credit_total`: the amount of money that each customer has already spent by using their line of credit
 
-As shown in [order-service-schema.json](order-service-schema.json) for the sample application, all the tables for the Order Service are created in the `order_service` namespace.
+As shown in [`order-service-schema.json`](order-service-schema.json) for the sample application, all the tables for the Order Service are created in the `order_service` namespace.
 
 - `order_service.orders`: a table that manages order information
 - `order_service.statements`: a table that manages order statement information
@@ -384,7 +384,7 @@ The following sequence diagram shows the transaction for placing an order:
 
 When a client sends a request to place an order to the Order Service, `OrderService.placeOrder()` is called, and the microservice transaction starts.
 
-At first, the Order Service starts a transaction with a two-phase commit interface with `start()` as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+At first, the Order Service starts a transaction with a two-phase commit interface with `start()` as follows. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction = twoPhaseCommitTransactionManager.start();
@@ -392,7 +392,7 @@ transaction = twoPhaseCommitTransactionManager.start();
 
 ### 2. CRUD operations are executed
 
-After the transaction with a two-phase commit interface starts, CRUD operations are executed. The Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
+After the transaction with a two-phase commit interface starts, CRUD operations are executed. The Order Service puts the order information in the `order_service.orders` table and the detailed information in the `order_service.statements` table as follows. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java):
 
 ```java
 // Put the order info into the `orders` table.
@@ -416,15 +416,15 @@ for (ItemOrder itemOrder : request.getItemOrderList()) {
 }
 ```
 
-Then, the Order Service calls the `payment` gRPC endpoint of the Customer Service along with the transaction ID. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+Then, the Order Service calls the `payment` gRPC endpoint of the Customer Service along with the transaction ID. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
-This endpoint first joins the transaction with `join()` as follows. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+This endpoint first joins the transaction with `join()` as follows. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 twoPhaseCommitTransactionManager.join(request.getTransactionId());
 ```
 
-The endpoint then gets the customer information and checks if the customer's credit total exceeds the credit limit after the payment. If the credit total does not exceed the credit limit, the endpoint updates the customer's credit total. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+The endpoint then gets the customer information and checks if the customer's credit total exceeds the credit limit after the payment. If the credit total does not exceed the credit limit, the endpoint updates the customer's credit total. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 // Join the transaction that the Order Service started.
@@ -457,14 +457,14 @@ Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTo
 
 After the Order Service receives the update that the payment succeeded, the Order Service tries to commit the transaction.
 
-To commit the transaction, the Order Service starts with preparing the transaction. The Order Service calls `prepare()` from its transaction object and calls the `prepare` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java):
+To commit the transaction, the Order Service starts with preparing the transaction. The Order Service calls `prepare()` from its transaction object and calls the `prepare` gRPC endpoint of the Customer Service. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java):
 
 ```java
 transaction.prepare();
 callPrepareEndpoint(transaction.getId());
 ```
 
-In this endpoint, the Customer Service resumes the transaction and calls `prepare()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java):
+In this endpoint, the Customer Service resumes the transaction and calls `prepare()` from its transaction object, as well. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java):
 
 ```java
 // Resume the transaction.
@@ -474,16 +474,16 @@ transaction = twoPhaseCommitTransactionManager.resume(request.getTransactionId()
 transaction.prepare();
 ```
 
-Similarly, the Order Service and the Customer Service call `validate()` from their transaction objects. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java) and [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java). For details about `validate()`, see [Validate the transaction](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#validate-the-transaction).
+Similarly, the Order Service and the Customer Service call `validate()` from their transaction objects. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java) and [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java). For details about `validate()`, see [Validate the transaction](https://github.com/scalar-labs/scalardb/blob/master/docs/two-phase-commit-transactions.md#validate-the-transaction).
 
-After preparing and validating the transaction succeeds in both the Order Service and the Customer Service, the transaction can be committed. In this case, the Order Service calls `commit()` from its transaction object and then calls the `commit` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+After preparing and validating the transaction succeeds in both the Order Service and the Customer Service, the transaction can be committed. In this case, the Order Service calls `commit()` from its transaction object and then calls the `commit` gRPC endpoint of the Customer Service. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction.commit();
 callCommitEndpoint(transaction.getId());
 ```
 
-In this endpoint, the Customer Service resumes the transaction and calls `commit()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+In this endpoint, the Customer Service resumes the transaction and calls `commit()` from its transaction object, as well. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 // Resume the transaction.
@@ -495,14 +495,14 @@ transaction.commit();
 
 ### Error handling
 
-If an error happens while executing a transaction, you will need to roll back the transaction. In this case, the Order Service calls `rollback()` from its transaction object and then calls the `rollback` gRPC endpoint of the Customer Service. For reference, see [OrderService.java](order-service/src/main/java/sample/order/OrderService.java).
+If an error happens while executing a transaction, you will need to roll back the transaction. In this case, the Order Service calls `rollback()` from its transaction object and then calls the `rollback` gRPC endpoint of the Customer Service. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 transaction.rollback();
 callRollbackEndpoint(transaction.getId());
 ```
 
-In this endpoint, the Customer Service resumes the transaction and calls `rollback()` from its transaction object, as well. For reference, see [CustomerService.java](customer-service/src/main/java/sample/customer/CustomerService.java).
+In this endpoint, the Customer Service resumes the transaction and calls `rollback()` from its transaction object, as well. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 // Resume the transaction.

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -88,7 +88,7 @@ Starting the Docker container may take more than one minute depending on your de
 
 The database schema (the method in which the data will be organized) for the sample application has already been defined in [schema.json](schema.json).
 
-To apply the schema, go to the [`scalardb` Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/multi-storage-transaction-sample` folder.
+To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/multi-storage-transaction-sample` folder.
 
 Then, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
 

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -13,7 +13,7 @@ In this tutorial, you will build an application that uses both Cassandra and MyS
 {% capture notice--info %}
 **Note**
 
-Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [Handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
+Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [How to handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#how-to-handle-exceptions).
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>
@@ -68,7 +68,7 @@ $ cd scalardb-samples/multi-storage-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [Configuration](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#configuration).
+Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, make sure Docker is running and then run the following command:
 

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -4,7 +4,7 @@ This tutorial describes how to create a sample application that supports the mul
 
 ## Overview
 
-The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of the [multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md) feature in ScalarDB.
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the basic [ScalarDB sample](../scalardb-sample) but takes advantage of the [multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md) feature in ScalarDB.
 
 In this tutorial, you will build an application that uses both Cassandra and MySQL. By using the multi-storage transactions feature in ScalarDB, you can execute a transaction that spans both Cassandra and MySQL.
 
@@ -68,7 +68,7 @@ $ cd scalardb-samples/multi-storage-transaction-sample
 
 ### Start Cassandra and MySQL
 
-Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
+Cassandra and MySQL are already configured for the sample application, as shown in [`database.properties`](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [How to configure ScalarDB to support multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#how-to-configure-scalardb-to-support-multi-storage-transactions).
 
 To start Cassandra and MySQL, which are included in the Docker container for the sample application, make sure Docker is running and then run the following command:
 
@@ -86,7 +86,7 @@ Starting the Docker container may take more than one minute depending on your de
 
 ### Load the schema
 
-The database schema (the method in which the data will be organized) for the sample application has already been defined in [schema.json](schema.json).
+The database schema (the method in which the data will be organized) for the sample application has already been defined in [`schema.json`](schema.json).
 
 To apply the schema, go to the [ScalarDB Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/multi-storage-transaction-sample` folder.
 
@@ -98,7 +98,7 @@ $ java -jar scalardb-schema-loader-<VERSION>.jar --config database.properties --
 
 #### Schema details
 
-As shown in [schema.json](schema.json) for the sample application, all the tables are created in the `customer` and `order` namespaces.
+As shown in [`schema.json`](schema.json) for the sample application, all the tables are created in the `customer` and `order` namespaces.
 
 - `customer.customers`: a table that manages customers' information
   - `credit_limit`: the maximum amount of money a lender will allow each customer to spend when using a line of credit

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -162,7 +162,7 @@ You should see the following output:
 ### Place an order
 
 Then, have customer ID `1` place an order for three apples and two oranges by running the following command:
-lol
+
 {% capture notice--info %}
 **Note**
 

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -1,93 +1,108 @@
-# Multi-storage Transaction Sample
+# Create a Sample Application That Supports Multi-Storage Transactions
 
-This tutorial describes how to create a sample application by using ScalarDB with Multi-storage Transactions.
+This tutorial describes how to create a sample application that supports the multi-storage transactions feature in ScalarDB.
 
-## Prerequisites
+## Overview
 
-- Java (OpenJDK 8 or higher)
-- Gradle
-- Docker, Docker Compose
+The sample e-commerce application shows how users can order and pay for items by using a line of credit. The use case described in this tutorial is the same as the [basic ScalarDB sample](../scalardb-sample) but takes advantage of the [multi-storage transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md) feature in ScalarDB.
 
-## Sample application
-
-### Overview
-
-This tutorial describes how to create a sample application for the same use case as [ScalarDB Sample](https://github.com/scalar-labs/scalardb-samples/tree/main/scalardb-sample) but by using ScalarDB with Multi-storage Transaction.
-In this tutorial, you will build an application that uses both Cassandra and MySQL.
-Using the Multi-storage Transaction feature of ScalarDB, you can execute a transaction that spans both Cassandra and MySQL.
-Please note that application-specific error handling, authentication processing, and similar functions are not included in the sample application, as the focus is on demonstrating the use of ScalarDB.
-For detailed information on exception handling in ScalarDB, see [Handle SQLException](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
+In this tutorial, you will build an application that uses both Cassandra and MySQL. By using the multi-storage transactions feature in ScalarDB, you can execute a transaction that spans both Cassandra and MySQL.
 
 ![Overview](images/overview.png)
 
-### Schema
+{% capture notice--info %}
+**Note**
 
-[The schema](schema.json) is as follows:
+Since the focus of the sample application is to demonstrate using ScalarDB, application-specific error handling, authentication processing, and similar functions are not included in the sample application. For details about exception handling in ScalarDB, see [Handle exceptions](https://github.com/scalar-labs/scalardb/blob/master/docs/api-guide.md#handle-exceptions).
+{% endcapture %}
 
-```json
-{
-  "customer.customers": {
-    "transaction": true,
-    "partition-key": [
-      "customer_id"
-    ],
-    "columns": {
-      "customer_id": "INT",
-      "name": "TEXT",
-      "credit_limit": "INT",
-      "credit_total": "INT"
-    }
-  },
-  "order.orders": {
-    "transaction": true,
-    "partition-key": [
-      "customer_id"
-    ],
-    "clustering-key": [
-      "timestamp"
-    ],
-    "secondary-index": [
-      "order_id"
-    ],
-    "columns": {
-      "order_id": "TEXT",
-      "customer_id": "INT",
-      "timestamp": "BIGINT"
-    }
-  },
-  "order.statements": {
-    "transaction": true,
-    "partition-key": [
-      "order_id"
-    ],
-    "clustering-key": [
-      "item_id"
-    ],
-    "columns": {
-      "order_id": "TEXT",
-      "item_id": "INT",
-      "count": "INT"
-    }
-  },
-  "order.items": {
-    "transaction": true,
-    "partition-key": [
-      "item_id"
-    ],
-    "columns": {
-      "item_id": "INT",
-      "name": "TEXT",
-      "price": "INT"
-    }
-  }
-}
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+### What you can do in this sample application
+
+The sample application supports the following types of transactions:
+
+- Get customer information.
+- Place an order by using a line of credit.
+  - Checks if the cost of the order is below the customer's credit limit.
+  - If the check passes, records the order history and updates the amount the customer has spent.
+- Get order information by order ID.
+- Get order information by customer ID.
+- Make a payment.
+  - Reduces the amount the customer has spent.
+
+## Prerequisites
+
+- One of the following Java Development Kits (JDKs):
+  - [Oracle JDK](https://www.oracle.com/java/technologies/downloads/) LTS version (8, 11, or 17)
+  - [OpenJDK](https://openjdk.org/install/) LTS version (8, 11, or 17)
+- [Docker](https://www.docker.com/get-started/) 20.10 or later with [Docker Compose](https://docs.docker.com/compose/install/) V2 or later
+
+{% capture notice--info %}
+**Note**
+
+We recommend using the LTS versions mentioned above, but other non-LTS versions may work.
+
+In addition, other JDKs should work with ScalarDB, but we haven't tested them.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+## Set up ScalarDB
+
+The following sections describe how to set up the sample application that supports the multi-storage transactions feature in ScalarDB.
+
+### Clone the ScalarDB samples repository
+
+Open **Terminal**, then clone the ScalarDB samples repository by running the following command:
+
+```console
+$ git clone https://github.com/scalar-labs/scalardb-samples
 ```
 
-All the tables are created in the `customer` and `order` namespaces.
+Then, go to the directory that contains the sample application by running the following command:
+
+```console
+$ cd scalardb-samples/multi-storage-transaction-sample
+```
+
+### Start Cassandra and MySQL
+
+Cassandra and MySQL are already configured for the sample application, as shown in [database.properties](database.properties). For details about configuring the multi-storage transactions feature in ScalarDB, see [Configuration](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#configuration).
+
+To start Cassandra and MySQL, which are included in the Docker container for the sample application, make sure Docker is running and then run the following command:
+
+```console
+$ docker-compose up -d
+```
+
+{% capture notice--info %}
+**Note**
+
+Starting the Docker container may take more than one minute depending on your development environment.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+### Load the schema
+
+The database schema (the method in which the data will be organized) for the sample application has already been defined in [schema.json](schema.json).
+
+To apply the schema, go to the [`scalardb` Releases](https://github.com/scalar-labs/scalardb/releases) page and download the ScalarDB Schema Loader that matches the version of ScalarDB that you want to use to the `scalardb-samples/multi-storage-transaction-sample` folder.
+
+Then, run the following command, replacing `<VERSION>` with the version of the ScalarDB Schema Loader that you downloaded:
+
+```console
+$ java -jar scalardb-schema-loader-<VERSION>.jar --config database.properties --schema-file schema.json --coordinator
+```
+
+#### Schema reference
+
+As shown in [schema.json](schema.json) for the sample application, all the tables are created in the `customer` and `order` namespaces.
 
 - `customer.customers`: a table that manages customers' information
-    - `credit_limit`: the maximum amount of money a lender will allow each customer to spend when using a credit card
-    - `credit_total`: the amount of money that each customer has already spent by using the credit card
+  - `credit_limit`: the maximum amount of money a lender will allow each customer to spend when using a line of credit
+  - `credit_total`: the amount of money that each customer has already spent by using their line of credit
 - `order.orders`: a table that manages order information
 - `order.statements`: a table that manages order statement information
 - `order.items`: a table that manages information of items to be ordered
@@ -96,76 +111,17 @@ The Entity Relationship Diagram for the schema is as follows:
 
 ![ERD](images/ERD.png)
 
-### Transactions
+### Load the initial data
 
-The following five transactions are implemented in this sample application:
+After the Docker container has started, load the initial data by running the following command:
 
-1. Getting customer information
-2. Placing an order by credit card (checks if the cost of the order is below the credit limit, then records order history and updates the `credit_total` if the check passes)
-3. Getting order information by order ID
-4. Getting order information by customer ID
-5. Repayment (reduces the amount in the `credit_total`)
-
-## Configuration
-
-Configurations for the sample application are as follows:
-
-```properties
-scalar.db.storage=multi-storage
-scalar.db.multi_storage.storages=cassandra,mysql
-scalar.db.multi_storage.storages.cassandra.storage=cassandra
-scalar.db.multi_storage.storages.cassandra.contact_points=localhost
-scalar.db.multi_storage.storages.cassandra.username=cassandra
-scalar.db.multi_storage.storages.cassandra.password=cassandra
-scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://localhost:3306/
-scalar.db.multi_storage.storages.mysql.username=root
-scalar.db.multi_storage.storages.mysql.password=mysql
-scalar.db.multi_storage.namespace_mapping=customer:mysql,order:cassandra,coordinator:cassandra
-scalar.db.multi_storage.default_storage=cassandra
-```
-
-- `scalar.db.storage`: Specifying `multi-storage` is necessary to use Multi-storage Transactions in ScalarDB.
-- `scalar.db.multi_storage.storages`: Your storage names must be defined here.
-- `scalar.db.multi_storage.storages.cassandra.*`: These configurations are for the `cassandra` storage, which is one of the storage names defined in `scalar.db.multi_storage.storages`. You can configure all the `scalar.db.*` properties for the `cassandra` storage here.
-- `scalar.db.multi_storage.storages.mysql.*`: These configurations are for the `mysql` storage, which is one of the storage names defined in `scalar.db.multi_storage.storages`. You can configure all the `scalar.db.*` properties for the `mysql` storage here.
-- `scalar.db.multi_storage.namespace_mapping`: This configuration maps the namespaces to the storage. In this sample application, operations for `customer` namespace tables are mapped to the `mysql` storage and operations for `order` namespace tables are mapped to the `cassandra` storage. You can also define which storage is mapped for the `coordinator` namespace that is used in Consensus Commit transactions.
-- `scalar.db.multi_storage.default_storage`: This configuration sets the default storage that is used for operations on unmapped namespace tables.
-
-For details, please see [Configuration - Multi-storage Transactions](https://github.com/scalar-labs/scalardb/blob/master/docs/multi-storage-transactions.md#configuration).
-
-## Setup
-
-### Start Cassandra and MySQL
-
-To start Cassandra and MySQL, you need to run the following `docker-compose` command:
-
-```shell
-$ docker-compose up -d
-```
-
-Please note that starting the containers may take more than one minute.
-
-### Load schema
-
-You then need to apply the schema with the following command.
-To download the schema loader tool, `scalardb-schema-loader-<VERSION>.jar`, see the [Releases](https://github.com/scalar-labs/scalardb/releases) of ScalarDB and download the version that you want to use.
-
-```shell
-$ java -jar scalardb-schema-loader-<VERSION>.jar --config database.properties --schema-file schema.json --coordinator
-```
-
-### Load initial data
-
-After the containers have started, you need to load the initial data by running the following command:
-
-```shell
+```console
 $ ./gradlew run --args="LoadInitialData"
 ```
 
-After the initial data has loaded, the following records should be stored in the tables:
+After the initial data has loaded, the following records should be stored in the tables.
 
-- For the `customer.customers` table:
+**`customer.customers` table**
 
 | customer_id | name          | credit_limit | credit_total |
 |-------------|---------------|--------------|--------------|
@@ -173,7 +129,7 @@ After the initial data has loaded, the following records should be stored in the
 | 2           | Yamada Hanako | 10000        | 0            |
 | 3           | Suzuki Ichiro | 10000        | 0            |
 
-- For the `order.items` table:
+**`order.items` table**
 
 | item_id | name   | price |
 |---------|--------|-------|
@@ -183,62 +139,123 @@ After the initial data has loaded, the following records should be stored in the
 | 4       | Mango  | 5000  |
 | 5       | Melon  | 3000  |
 
-## Run the sample application
+## Execute transactions and retrieve data in the sample application
 
-Let's start with getting information about the customer whose ID is `1`:
+The following sections describe how to execute transactions and retrieve data in the sample e-commerce application.
 
-```shell
+### Get customer information
+
+Start with getting information about the customer whose ID is `1` by running the following command:
+
+```console
 $ ./gradlew run --args="GetCustomerInfo 1"
+```
+
+You should see the following output:
+
+```console
 ...
 {"id": 1, "name": "Yamada Taro", "credit_limit": 10000, "credit_total": 0}
 ...
 ```
 
-Then, place an order for three apples and two oranges by using customer ID `1`.
-Note that the order format is `<Item ID>:<Count>,<Item ID>:<Count>,...`:
+### Place an order
 
-```shell
+Then, have customer ID `1` place an order for three apples and two oranges by running the following command:
+lol
+{% capture notice--info %}
+**Note**
+
+The order format in this command is `./gradlew run --args="PlaceOrder <CUSTOMER_ID> <ITEM_ID>:<COUNT>,<ITEM_ID>:<COUNT>,..."`.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
+
+```console
 $ ./gradlew run --args="PlaceOrder 1 1:3,2:2"
+```
+
+You should see a similar output as below, with a different UUID for `order_id`, which confirms that the order was successful:
+
+```console
 ...
-{"order_id": "9099eca6-98b8-4ef5-a803-3166dfe635ad"}
+{"order_id": "dea4964a-ff50-4ecf-9201-027981a1566e"}
 ...
 ```
 
-You can see that running this command shows the order ID.
+### Check order details
 
-Let's check the details of the order by using the order ID:
+Check details about the order by running the following command, replacing `<ORDER_ID_UUID>` with the UUID for the `order_id` that was shown after running the previous command:
 
-```shell
-$ ./gradlew run --args="GetOrder 9099eca6-98b8-4ef5-a803-3166dfe635ad"
+```console
+$ ./gradlew run --args="GetOrder <ORDER_ID_UUID>"
+```
+
+You should see a similar output as below, with different UUIDs for `order_id` and `timestamp`:
+
+```console
 ...
-{"order": {"order_id": "9099eca6-98b8-4ef5-a803-3166dfe635ad","timestamp": 1652668907742,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 1,"item_name": "Apple","price": 1000,"count": 3,"total": 3000},{"item_id": 2,"item_name": "Orange","price": 2000,"count": 2,"total": 4000}],"total": 7000}}
+{"order": {"order_id": "dea4964a-ff50-4ecf-9201-027981a1566e","timestamp": 1650948340914,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 1,"item_name": "Apple","price": 1000,"count": 3,"total": 3000},{"item_id": 2,"item_name": "Orange","price": 2000,"count": 2,"total": 4000}],"total": 7000}}
 ...
 ```
 
-Then, let's place another order and get the order history of customer ID `1`:
+### Place another order
 
-```shell
+Place an order for one melon that uses the remaining amount in `credit_total` for customer ID `1` by running the following command:
+
+```console
 $ ./gradlew run --args="PlaceOrder 1 5:1"
+```
+
+You should see a similar output as below, with a different UUID for `order_id`, which confirms that the order was successful:
+
+```console
 ...
-{"order_id": "cff41250-01aa-4a4e-ae1c-651b74bb1cff"}
-...
-$ ./gradlew run --args="GetOrders 1"
-...
-{"order": [{"order_id": "9099eca6-98b8-4ef5-a803-3166dfe635ad","timestamp": 1652668907742,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 1,"item_name": "Apple","price": 1000,"count": 3,"total": 3000},{"item_id": 2,"item_name": "Orange","price": 2000,"count": 2,"total": 4000}],"total": 7000},{"order_id": "cff41250-01aa-4a4e-ae1c-651b74bb1cff","timestamp": 1652668943114,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 5,"item_name": "Melon","price": 3000,"count": 1,"total": 3000}],"total": 3000}]}
+{"order_id": "bcc34150-91fa-4bea-83db-d2dbe6f0f30d"}
 ...
 ```
 
-This order history is shown in descending order by timestamp.
+### Check order history
 
-The customer's current `credit_total` is `10000`.
-Since the customer has now reached their `credit_limit`, which was shown when retrieving their information, they cannot place anymore orders.
+Get the history of all orders for customer ID `1` by running the following command:
 
-```shell
+```console
+$ ./gradlew run --args="GetOrders 1"
+```
+
+You should see a similar output as below, with different UUIDs for `order_id` and `timestamp`, which shows the history of all orders for customer ID `1` in descending order by timestamp:
+
+```console
+...
+{"order": [{"order_id": "dea4964a-ff50-4ecf-9201-027981a1566e","timestamp": 1650948340914,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 1,"item_name": "Apple","price": 1000,"count": 3,"total": 3000},{"item_id": 2,"item_name": "Orange","price": 2000,"count": 2,"total": 4000}],"total": 7000},{"order_id": "bcc34150-91fa-4bea-83db-d2dbe6f0f30d","timestamp": 1650948412766,"customer_id": 1,"customer_name": "Yamada Taro","statement": [{"item_id": 5,"item_name": "Melon","price": 3000,"count": 1,"total": 3000}],"total": 3000}]}
+...
+```
+
+### Check credit total
+
+Get the credit total for customer ID `1` by running the following command:
+
+```console
 $ ./gradlew run --args="GetCustomerInfo 1"
+```
+
+You should see the following output, which shows that customer ID `1` has reached their `credit_limit` in `credit_total` and cannot place anymore orders:
+
+```console
 ...
 {"id": 1, "name": "Yamada Taro", "credit_limit": 10000, "credit_total": 10000}
 ...
+```
+
+Try to place an order for one grape and one mango by running the following command:
+
+```console
 $ ./gradlew run --args="PlaceOrder 1 3:1,4:1"
+```
+
+You should see the following output, which shows that the order failed because the `credit_total` amount would exceed the `credit_limit` amount:
+
+```console
 ...
 java.lang.RuntimeException: Credit limit exceeded
         at sample.Sample.placeOrder(Sample.java:205)
@@ -254,25 +271,49 @@ java.lang.RuntimeException: Credit limit exceeded
 ...
 ```
 
-After making a payment, the customer will be able to place orders again.
+### Make a payment
 
-```shell
+To continue making orders, customer ID `1` must make a payment to reduce the `credit_total` amount.
+
+Make a payment by running the following command:
+
+```console
 $ ./gradlew run --args="Repayment 1 8000"
-...
+```
+
+Then, check the `credit_total` amount for customer ID `1` by running the following command:
+
+```console
 $ ./gradlew run --args="GetCustomerInfo 1"
+```
+
+You should see the following output, which shows that a payment was applied to customer ID `1`, reducing the `credit_total` amount:
+
+```console
 ...
 {"id": 1, "name": "Yamada Taro", "credit_limit": 10000, "credit_total": 2000}
 ...
+```
+
+Now that customer ID `1` has made a payment, place an order for one grape and one melon by running the following command:
+
+```console
 $ ./gradlew run --args="PlaceOrder 1 3:1,4:1"
+```
+
+You should see a similar output as below, with a different UUID for `order_id`, which confirms that the order was successful:
+
+```console
 ...
-{"order_id": "4b1c5f53-e2fb-4489-be1f-cfc2aef29123"}
+{"order_id": "8911cab3-1c2b-4322-9386-adb1c024e078"}
+The balance for merchant1 is 100
 ...
 ```
 
-## Clean up
+## Stop the sample application
 
-To stop Cassandra and MySQL, run the following command:
+To stop the sample application, stop the Docker container by running the following command:
 
-```shell
+```console
 $ docker-compose down
 ```

--- a/multi-storage-transaction-sample/README.md
+++ b/multi-storage-transaction-sample/README.md
@@ -96,7 +96,7 @@ Then, run the following command, replacing `<VERSION>` with the version of the S
 $ java -jar scalardb-schema-loader-<VERSION>.jar --config database.properties --schema-file schema.json --coordinator
 ```
 
-#### Schema reference
+#### Schema details
 
 As shown in [schema.json](schema.json) for the sample application, all the tables are created in the `customer` and `order` namespaces.
 


### PR DESCRIPTION
## Description

This PR revises the ScalarDB tutorials for:

- Creating a sample application that supports multi-storage transactions.
- Creating a sample application that supports microservice transactions.

## Related issues and/or PRs

Related to https://github.com/scalar-labs/scalardb-samples/pull/49

## Changes made

- Revised both tutorials, adding headings and providing additional context to the instructions.

> **Note**
> 
> Many of the formatting and editorial changes in this sample tutorial are similar to the changes I recently made to the "Create a Sample Application by Using ScalarDB" tutorial in https://github.com/scalar-labs/scalardb-samples/pull/49.

## Branches this PR applies to

- `main`

## How these changes were tested

I built our docs site locally and confirmed that these two sample tutorials, including headings and notice blocks, appeared as expected.

### Multi-storage transactions tutorial screenshot

![multi-storage-transaction-sample](https://github.com/scalar-labs/scalardb-samples/assets/23216828/20d14d7b-1c70-43b2-bdba-2fc8b033e64a)

### Microservice transactions tutorial screenshot

![microservice-transaction-sample](https://github.com/scalar-labs/scalardb-samples/assets/23216828/3957acaf-365c-4488-a796-0d5497aa290f)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

## Release notes

N/A