### PR TITLE
Remove `Release note` section in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,11 +24,3 @@
 ## Additional notes (optional)
 
 > Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
-
-## Release notes
-
-> Provide release note text for this PR based on the guidelines at [Guidelines for Writing Release Notes](https://developers.scalar-labs.com/docs/style-guide/release-notes/).
-> 
-> For example:
-> 
-> Added validation for the Consensus Commit mutation operation.


### PR DESCRIPTION
## Description

This PR removes the `## Release note` section since we don't need it when submitting PRs in this repository.

## Related issues and/or PRs

Related to https://github.com/scalar-labs/scalardb-samples/pull/51 (I hadn't noticed a [comment](https://github.com/scalar-labs/scalardb-samples/pull/51#issuecomment-1742984854) about removing this section in the original PR.)

## Changes made

Removed the `## Release note` section.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
