### PR TITLE
Microservice samples should call `CustomerService.getCustomerInfo` in a global transaction

### DIFF
--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -383,7 +383,7 @@ $ docker-compose down
 
 ## Reference - How the microservice transaction is achieved
 
-The transaction for placing an order achieves the microservice transaction, so this section focuses on how the transaction that spans the Customer Service and the Order Service is implemented.
+The transactions for placing an order, getting an order and getting orders achieve the microservice transaction, so this section focuses on how the transactions that span the Customer Service and the Order Service are implemented by taking placing an order as an example.
 
 The following sequence diagram shows the transaction for placing an order:
 
@@ -430,36 +430,43 @@ Then, the Order Service calls the `payment` gRPC endpoint of the Customer Servic
 This endpoint first joins the transaction with `join()` as follows. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
-twoPhaseCommitTransactionManager.join(request.getTransactionId());
+private <T> void execOperationsAsParticipant(String funcName, String transactionId,
+  TransactionFunction<TransactionCrudOperable, T> operations,
+  StreamObserver<T> responseObserver) {
+  try {
+    // Join the transaction
+    TwoPhaseCommitTransaction transaction = twoPhaseCommitTransactionManager.join(transactionId);
+
+    // Execute operations
+    T response = operations.apply(transaction);
 ```
 
 The endpoint then gets the customer information and checks if the customer's credit total exceeds the credit limit after the payment. If the credit total does not exceed the credit limit, the endpoint updates the customer's credit total. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
-// Join the transaction that the Order Service started.
-transaction = twoPhaseCommitTransactionManager.join(request.getTransactionId());
+execOperationsAsParticipant("Payment", request.getTransactionId(),
+  transaction -> {
+    // Retrieve the customer info for the customer ID
+    Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
+    if (!result.isPresent()) {
+      throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
+    }
 
-// Retrieve the customer info for the customer ID.
-Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
-if (!result.isPresent()) {
-  responseObserver.onError(
-      Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException());
-  return;
-}
+    int updatedCreditTotal = result.get().creditTotal + request.getAmount();
 
-int updatedCreditTotal = result.get().creditTotal + request.getAmount();
+    // Check if the credit total exceeds the credit limit after payment
+    if (updatedCreditTotal > result.get().creditLimit) {
+      throw Status.FAILED_PRECONDITION
+        .withDescription("Credit limit exceeded")
+        .asRuntimeException();
+    }
 
-// Check if the credit total exceeds the credit limit after payment.
-if (updatedCreditTotal > result.get().creditLimit) {
-  responseObserver.onError(
-      Status.FAILED_PRECONDITION
-          .withDescription("Credit limit exceeded")
-          .asRuntimeException());
-  return;
-}
+    // Update `credit_total` for the customer
+    Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
 
-// Update `credit_total` for the customer.
-Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
+    return Empty.getDefaultInstance();
+  }, responseObserver
+);
 ```
 
 ### 3. Transaction is committed by using the two-phase commit protocol

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -63,7 +63,13 @@ The sample application supports the following types of transactions:
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
-Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. We intentionally separated the endpoints to keep them simple as a sample application.
+{% capture notice--info %}
+**Note**
+
+Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. The endpoints are intentionally separated for the sake of simplifying them in the sample application.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ## Prerequisites
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -37,7 +37,6 @@ The endpoints defined in the services are as follows:
 
 - Customer Service
   - `getCustomerInfo`
-  - `getCustomerInfoForTwoPhaseCommit`
   - `payment`
   - `prepare`
   - `validate`
@@ -58,15 +57,16 @@ The sample application supports the following types of transactions:
 - Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
-- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfo`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfo`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
 {% capture notice--info %}
 **Note**
 
-Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. The endpoints are intentionally separated for the sake of simplifying them in the sample application.
+`getCustomerInfo` endpoint works as a participant service endpoint when receiving a transaction ID from the coordinator.
+
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -65,7 +65,7 @@ The sample application supports the following types of transactions:
 {% capture notice--info %}
 **Note**
 
-`getCustomerInfo` endpoint works as a participant service endpoint when receiving a transaction ID from the coordinator.
+The `getCustomerInfo` endpoint works as a participant service endpoint when receiving a transaction ID from the coordinator.
 
 {% endcapture %}
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -58,8 +58,8 @@ The sample application supports the following types of transactions:
 - Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
-- Get order information by customer ID through the `getOrders` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -383,7 +383,7 @@ $ docker-compose down
 
 ## Reference - How the microservice transaction is achieved
 
-The transactions for placing an order, getting an order and getting orders achieve the microservice transaction, so this section focuses on how the transactions that span the Customer Service and the Order Service are implemented by taking placing an order as an example.
+The transactions for placing an order, getting a single order, and getting the history of orders achieve the microservice transaction. This section focuses on how the transactions that span the Customer Service and the Order Service are implemented by placing an order as an example.
 
 The following sequence diagram shows the transaction for placing an order:
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -427,7 +427,16 @@ for (ItemOrder itemOrder : request.getItemOrderList()) {
 
 Then, the Order Service calls the `payment` gRPC endpoint of the Customer Service along with the transaction ID. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
-This endpoint first joins the transaction with `join()` as follows. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
+```java
+customerServiceStub.payment(
+  PaymentRequest.newBuilder()
+    .setTransactionId(transactionId)
+    .setCustomerId(customerId)
+    .setAmount(amount)
+    .build());
+```
+
+The `payment` endpoint of the Customer Service first joins the transaction with `join()` as follows. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 private <T> void execOperationsAsParticipant(String funcName, String transactionId,

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -37,6 +37,7 @@ The endpoints defined in the services are as follows:
 
 - Customer Service
   - `getCustomerInfo`
+  - `getCustomerInfoForTwoPhaseCommit`
   - `payment`
   - `prepare`
   - `validate`
@@ -57,8 +58,8 @@ The sample application supports the following types of transactions:
 - Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` of the Order Service.
-- Get order information by customer ID through the `getOrders` of the Order Service.
+- Get order information by order ID through the `getOrder` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 

--- a/microservice-transaction-sample/README.md
+++ b/microservice-transaction-sample/README.md
@@ -63,6 +63,8 @@ The sample application supports the following types of transactions:
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
+Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. We intentionally separated the endpoints to keep them simple as a sample application.
+
 ## Prerequisites
 
 - One of the following Java Development Kits (JDKs):

--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -3,6 +3,7 @@ package sample.customer;
 import com.google.protobuf.Empty;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
+import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.api.TwoPhaseCommitTransaction;
 import com.scalar.db.api.TwoPhaseCommitTransactionManager;
 import com.scalar.db.exception.transaction.AbortException;
@@ -40,6 +41,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
   // For two-phase commit transactions
   private final TwoPhaseCommitTransactionManager twoPhaseCommitTransactionManager;
 
+  private interface TransactionFunction<T, R> {
+    R apply(T t) throws TransactionException;
+  }
+
   public CustomerService(String configFile) throws TransactionException, IOException {
     // Initialize the transaction managers
     TransactionFactory factory = TransactionFactory.create(configFile);
@@ -76,54 +81,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
   @Override
   public void getCustomerInfo(
       GetCustomerInfoRequest request, StreamObserver<GetCustomerInfoResponse> responseObserver) {
-    DistributedTransaction transaction = null;
-    try {
-      // Start a transaction
-      transaction = transactionManager.start();
-
-      // Retrieve the customer info for the specified customer ID
-      Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
-
-      if (!result.isPresent()) {
-        // If the customer info the specified customer ID doesn't exist, throw an exception
-        throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
-      }
-
-      // Commit the transaction (even when the transaction is read-only, we need to commit)
-      transaction.commit();
-
-      // Return the customer info
-      responseObserver.onNext(
-          GetCustomerInfoResponse.newBuilder()
-              .setId(result.get().id)
-              .setName(result.get().name)
-              .setCreditLimit(result.get().creditLimit)
-              .setCreditTotal(result.get().creditTotal)
-              .build());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Getting customer info failed", e);
-      abortTransaction(transaction);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Getting customer info failed";
-      logger.error(message, e);
-      abortTransaction(transaction);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
-    }
-  }
-
-  @Override
-  public void getCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest request,
-      StreamObserver<GetCustomerInfoResponse> responseObserver) {
-    try {
-      if (!request.hasTransactionId()) {
-        throw Status.INVALID_ARGUMENT.withDescription("Transaction ID isn't set").asRuntimeException();
-      }
-      // Start a transaction
-      TwoPhaseCommitTransaction transaction = twoPhaseCommitTransactionManager.join(request.getTransactionId());
-
+    String funcName = "Getting customer info";
+    // This function processing operations can be used in both normal transaction and two-phase
+    // interface transaction.
+    TransactionFunction<TransactionCrudOperable, GetCustomerInfoResponse> task = transaction -> {
       // Retrieve the customer info for the specified customer ID
       Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
 
@@ -133,65 +94,44 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
       }
 
       // Return the customer info
-      responseObserver.onNext(
-          GetCustomerInfoResponse.newBuilder()
-              .setId(result.get().id)
-              .setName(result.get().name)
-              .setCreditLimit(result.get().creditLimit)
-              .setCreditTotal(result.get().creditTotal)
-              .build());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Getting customer info failed", e);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Getting customer info failed";
-      logger.error(message, e);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
+      return GetCustomerInfoResponse.newBuilder()
+          .setId(result.get().id)
+          .setName(result.get().name)
+          .setCreditLimit(result.get().creditLimit)
+          .setCreditTotal(result.get().creditTotal)
+          .build();
+    };
+
+    if (request.hasTransactionId()) {
+      execOperationsAsParticipant(funcName, request.getTransactionId(), task, responseObserver);
+    } else {
+      execOperations(funcName, task, responseObserver);
     }
   }
 
   @Override
   public void repayment(RepaymentRequest request, StreamObserver<Empty> responseObserver) {
-    DistributedTransaction transaction = null;
-    try {
-      // Start a transaction
-      transaction = transactionManager.start();
+    execOperations("Repayment",
+        transaction -> {
+          // Retrieve the customer info for the specified customer ID
+          Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
+          if (!result.isPresent()) {
+            // If the customer info the specified customer ID doesn't exist, throw an exception
+            throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
+          }
 
-      // Retrieve the customer info for the specified customer ID
-      Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
-      if (!result.isPresent()) {
-        // If the customer info the specified customer ID doesn't exist, throw an exception
-        throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
-      }
+          int updatedCreditTotal = result.get().creditTotal - request.getAmount();
 
-      int updatedCreditTotal = result.get().creditTotal - request.getAmount();
+          // Check if over repayment or not
+          if (updatedCreditTotal < 0) {
+            throw Status.FAILED_PRECONDITION.withDescription("Over repayment").asRuntimeException();
+          }
 
-      // Check if over repayment or not
-      if (updatedCreditTotal < 0) {
-        throw Status.FAILED_PRECONDITION.withDescription("Over repayment").asRuntimeException();
-      }
+          // Reduce credit_total for the customer
+          Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
 
-      // Reduce credit_total for the customer
-      Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
-
-      // Commit the transaction (even when the transaction is read-only, we need to commit)
-      transaction.commit();
-
-      responseObserver.onNext(Empty.getDefaultInstance());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Repayment failed", e);
-      abortTransaction(transaction);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Repayment failed";
-      logger.error(message, e);
-      abortTransaction(transaction);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
-    }
+          return Empty.getDefaultInstance();
+        }, responseObserver);
   }
 
   private void abortTransaction(@Nullable DistributedTransaction transaction) {
@@ -207,40 +147,29 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
 
   @Override
   public void payment(PaymentRequest request, StreamObserver<Empty> responseObserver) {
-    try {
-      // Join the transaction that the order service started
-      TwoPhaseCommitTransaction transaction =
-          twoPhaseCommitTransactionManager.join(request.getTransactionId());
+    execOperationsAsParticipant("Payment", request.getTransactionId(),
+        transaction -> {
+          // Retrieve the customer info for the customer ID
+          Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
+          if (!result.isPresent()) {
+            throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
+          }
 
-      // Retrieve the customer info for the customer ID
-      Optional<Customer> result = Customer.get(transaction, request.getCustomerId());
-      if (!result.isPresent()) {
-        throw Status.NOT_FOUND.withDescription("Customer not found").asRuntimeException();
-      }
+          int updatedCreditTotal = result.get().creditTotal + request.getAmount();
 
-      int updatedCreditTotal = result.get().creditTotal + request.getAmount();
+          // Check if the credit total exceeds the credit limit after payment
+          if (updatedCreditTotal > result.get().creditLimit) {
+            throw Status.FAILED_PRECONDITION
+                .withDescription("Credit limit exceeded")
+                .asRuntimeException();
+          }
 
-      // Check if the credit total exceeds the credit limit after payment
-      if (updatedCreditTotal > result.get().creditLimit) {
-        throw Status.FAILED_PRECONDITION
-            .withDescription("Credit limit exceeded")
-            .asRuntimeException();
-      }
+          // Update credit_total for the customer
+          Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
 
-      // Update credit_total for the customer
-      Customer.updateCreditTotal(transaction, request.getCustomerId(), updatedCreditTotal);
-
-      responseObserver.onNext(Empty.getDefaultInstance());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Payment failed", e);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Payment failed";
-      logger.error(message, e);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
-    }
+          return Empty.getDefaultInstance();
+        }, responseObserver
+    );
   }
 
   @Override
@@ -321,6 +250,58 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
       responseObserver.onCompleted();
     } catch (Exception e) {
       String message = "Rollback failed";
+      logger.error(message, e);
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
+    }
+  }
+
+  private <T> void execOperations(String funcName,
+      TransactionFunction<TransactionCrudOperable, T> task, StreamObserver<T> responseObserver) {
+    DistributedTransaction transaction = null;
+    try {
+      // Start a transaction
+      transaction = transactionManager.start();
+
+      // Execute operations
+      T response = task.apply(transaction);
+
+      // Commit the transaction (even when the transaction is read-only, we need to commit)
+      transaction.commit();
+
+      // Return the response
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (StatusRuntimeException e) {
+      logger.error("{} failed", funcName, e);
+      abortTransaction(transaction);
+      responseObserver.onError(e);
+    } catch (Exception e) {
+      String message = funcName + " failed";
+      logger.error(message, e);
+      abortTransaction(transaction);
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
+    }
+  }
+
+  private <T> void execOperationsAsParticipant(String funcName, String transactionId,
+      TransactionFunction<TransactionCrudOperable, T> task, StreamObserver<T> responseObserver) {
+    try {
+      // Start a transaction
+      TwoPhaseCommitTransaction transaction = twoPhaseCommitTransactionManager.join(transactionId);
+
+      // Execute operations
+      T response = task.apply(transaction);
+
+      // Return the response
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    } catch (StatusRuntimeException e) {
+      logger.error("{} failed", funcName, e);
+      responseObserver.onError(e);
+    } catch (Exception e) {
+      String message = funcName + " failed";
       logger.error(message, e);
       responseObserver.onError(
           Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());

--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -115,7 +115,7 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
   }
 
   @Override
-  public void getCustomerInfoInTwoPhaseCommit(GetCustomerInfoRequest request,
+  public void getCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest request,
       StreamObserver<GetCustomerInfoResponse> responseObserver) {
     try {
       if (!request.hasTransactionId()) {

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -325,7 +325,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
         throw exception;
       }
 
-      // Return the order id
+      // Return the response
       responseObserver.onNext(result);
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -321,7 +321,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
 
   private String getCustomerName(String transactionId, int customerId) {
     GetCustomerInfoResponse customerInfo =
-        customerServiceStub.getCustomerInfoInTwoPhaseCommit(
+        customerServiceStub.getCustomerInfoForTwoPhaseCommit(
             GetCustomerInfoRequest.newBuilder()
                 .setTransactionId(transactionId)
                 .setCustomerId(customerId).build());

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -102,7 +102,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   @Override
   public void placeOrder(
       PlaceOrderRequest request, StreamObserver<PlaceOrderResponse> responseObserver) {
-    execInTwoPhaseCommit(responseObserver, "Getting an order",
+    execInTwoPhaseCommit(responseObserver, "Placing an order",
         (transaction) -> {
           String orderId = UUID.randomUUID().toString();
 

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -56,7 +56,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   private final ManagedChannel channel;
   private final CustomerServiceGrpc.CustomerServiceBlockingStub customerServiceStub;
 
-  interface TransactionFunction<T, R> {
+  private interface TransactionFunction<T, R> {
     R apply(T t) throws TransactionException;
   }
 

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -56,6 +56,10 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   private final ManagedChannel channel;
   private final CustomerServiceGrpc.CustomerServiceBlockingStub customerServiceStub;
 
+  interface TransactionFunction<T, R> {
+    R apply(T t) throws TransactionException;
+  }
+
   public OrderService(String configFile) throws TransactionException, IOException {
     // Initialize the transaction managers
     TransactionFactory factory = TransactionFactory.create(configFile);
@@ -98,79 +102,34 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   @Override
   public void placeOrder(
       PlaceOrderRequest request, StreamObserver<PlaceOrderResponse> responseObserver) {
-    TwoPhaseCommitTransaction transaction = null;
-    try {
-      String orderId = UUID.randomUUID().toString();
+    execInTwoPhaseCommit(responseObserver, "Getting an order",
+        (transaction) -> {
+          String orderId = UUID.randomUUID().toString();
 
-      // Start a two-phase commit transaction
-      transaction = twoPhaseCommitTransactionManager.start();
+          // Put the order info into the orders table
+          Order.put(transaction, orderId, request.getCustomerId(), System.currentTimeMillis());
 
-      // Put the order info into the orders table
-      Order.put(transaction, orderId, request.getCustomerId(), System.currentTimeMillis());
+          int amount = 0;
+          for (ItemOrder itemOrder : request.getItemOrderList()) {
+            // Put the order statement into the statements table
+            Statement.put(transaction, orderId, itemOrder.getItemId(), itemOrder.getCount());
 
-      int amount = 0;
-      for (ItemOrder itemOrder : request.getItemOrderList()) {
-        // Put the order statement into the statements table
-        Statement.put(transaction, orderId, itemOrder.getItemId(), itemOrder.getCount());
+            // Retrieve the item info from the items table
+            Optional<Item> item = Item.get(transaction, itemOrder.getItemId());
+            if (!item.isPresent()) {
+              throw Status.NOT_FOUND.withDescription("Item not found").asRuntimeException();
+            }
 
-        // Retrieve the item info from the items table
-        Optional<Item> item = Item.get(transaction, itemOrder.getItemId());
-        if (!item.isPresent()) {
-          throw Status.NOT_FOUND.withDescription("Item not found").asRuntimeException();
+            // Calculate the total amount
+            amount += item.get().price * itemOrder.getCount();
+          }
+
+          // Call the payment endpoint of Customer service
+          callPaymentEndpoint(transaction.getId(), request.getCustomerId(), amount);
+
+          return PlaceOrderResponse.newBuilder().setOrderId(orderId).build();
         }
-
-        // Calculate the total amount
-        amount += item.get().price * itemOrder.getCount();
-      }
-
-      // Call the payment endpoint of Customer service
-      callPaymentEndpoint(transaction.getId(), request.getCustomerId(), amount);
-
-      // Prepare the transaction
-      transaction.prepare();
-      callPrepareEndpoint(transaction.getId());
-
-      // Validate the transaction. Depending on the concurrency control protocol, you need to call
-      // validate(). Currently, you need to call it when you use the Consensus Commit transaction
-      // manager and EXTRA_READ serializable strategy in SERIALIZABLE isolation level. In other
-      // cases, validate() does nothing.
-      transaction.validate();
-      callValidateEndpoint(transaction.getId());
-
-      // Commit the transaction. If any of services succeed in committing the transaction, you can
-      // consider the transaction as committed.
-      boolean committed = false;
-      Exception exception = null;
-      try {
-        transaction.commit();
-        committed = true;
-      } catch (TransactionException e) {
-        exception = e;
-      }
-      try {
-        callCommitEndpoint(transaction.getId());
-        committed = true;
-      } catch (StatusRuntimeException e) {
-        exception = e;
-      }
-      if (!committed) {
-        throw exception;
-      }
-
-      // Return the order id
-      responseObserver.onNext(PlaceOrderResponse.newBuilder().setOrderId(orderId).build());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Placing an order failed", e);
-      rollbackTransaction(transaction);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Placing an order failed";
-      logger.error(message, e);
-      rollbackTransaction(transaction);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
-    }
+    );
   }
 
   private void rollbackTransaction(@Nullable TwoPhaseCommitTransaction transaction) {
@@ -221,79 +180,103 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   /** Get Order information by order ID */
   @Override
   public void getOrder(GetOrderRequest request, StreamObserver<GetOrderResponse> responseObserver) {
-    DistributedTransaction transaction = null;
-    try {
-      // Start a transaction
-      transaction = transactionManager.start();
+    execInTwoPhaseCommit(responseObserver, "Getting an order",
+        (transaction) -> {
+          // Retrieve the order info for the specified order ID
+          Optional<Order> order = Order.getById(transaction, request.getOrderId());
+          if (!order.isPresent()) {
+            throw Status.NOT_FOUND.withDescription("Order not found").asRuntimeException();
+          }
 
-      // Retrieve the order info for the specified order ID
-      Optional<Order> order = Order.getById(transaction, request.getOrderId());
-      if (!order.isPresent()) {
-        throw Status.NOT_FOUND.withDescription("Order not found").asRuntimeException();
-      }
+          // Make an order protobuf to return
+          sample.rpc.Order rpcOrder = getOrder(transaction, order.get());
 
-      // Make an order protobuf to return
-      sample.rpc.Order rpcOrder = getOrder(transaction, order.get());
-
-      // Commit the transaction (even when the transaction is read-only, we need to commit)
-      transaction.commit();
-
-      responseObserver.onNext(GetOrderResponse.newBuilder().setOrder(rpcOrder).build());
-      responseObserver.onCompleted();
-    } catch (StatusRuntimeException e) {
-      logger.error("Getting an order failed", e);
-      abortTransaction(transaction);
-      responseObserver.onError(e);
-    } catch (Exception e) {
-      String message = "Getting an order failed";
-      logger.error(message, e);
-      abortTransaction(transaction);
-      responseObserver.onError(
-          Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
-    }
+          return GetOrderResponse.newBuilder().setOrder(rpcOrder).build();
+        }
+    );
   }
 
   /** Get Order information by customer ID */
   @Override
   public void getOrders(
       GetOrdersRequest request, StreamObserver<GetOrdersResponse> responseObserver) {
-    DistributedTransaction transaction = null;
+    execInTwoPhaseCommit(responseObserver, "Getting orders",
+        (transaction) -> {
+          // Retrieve the order info for the specified customer ID
+          List<Order> orders = Order.getByCustomerId(transaction, request.getCustomerId());
+
+          GetOrdersResponse.Builder builder = GetOrdersResponse.newBuilder();
+          for (Order order : orders) {
+            // Make an order protobuf to return
+            sample.rpc.Order rpcOrder = getOrder(transaction, order);
+            builder.addOrder(rpcOrder);
+          }
+
+          return builder.build();
+        }
+    );
+  }
+
+  private <T> void execInTwoPhaseCommit(StreamObserver<T> responseObserver,
+      String funcName, TransactionFunction<TwoPhaseCommitTransaction, T> task) {
+    TwoPhaseCommitTransaction transaction = null;
     try {
-      // Start a transaction
-      transaction = transactionManager.start();
+      // Start a two-phase commit transaction
+      transaction = twoPhaseCommitTransactionManager.start();
 
-      // Retrieve the order info for the specified customer ID
-      List<Order> orders = Order.getByCustomerId(transaction, request.getCustomerId());
+      T result = task.apply(transaction);
 
-      GetOrdersResponse.Builder builder = GetOrdersResponse.newBuilder();
-      for (Order order : orders) {
-        // Make an order protobuf to return
-        sample.rpc.Order rpcOrder = getOrder(transaction, order);
-        builder.addOrder(rpcOrder);
+      // Prepare the transaction
+      transaction.prepare();
+      callPrepareEndpoint(transaction.getId());
+
+      // Validate the transaction. Depending on the concurrency control protocol, you need to call
+      // validate(). Currently, you need to call it when you use the Consensus Commit transaction
+      // manager and EXTRA_READ serializable strategy in SERIALIZABLE isolation level. In other
+      // cases, validate() does nothing.
+      transaction.validate();
+      callValidateEndpoint(transaction.getId());
+
+      // Commit the transaction. If any of services succeed in committing the transaction, you can
+      // consider the transaction as committed.
+      boolean committed = false;
+      Exception exception = null;
+      try {
+        transaction.commit();
+        committed = true;
+      } catch (TransactionException e) {
+        exception = e;
+      }
+      try {
+        callCommitEndpoint(transaction.getId());
+        committed = true;
+      } catch (StatusRuntimeException e) {
+        exception = e;
+      }
+      if (!committed) {
+        throw exception;
       }
 
-      // Commit the transaction (even when the transaction is read-only, we need to commit)
-      transaction.commit();
-
-      responseObserver.onNext(builder.build());
+      // Return the order id
+      responseObserver.onNext(result);
       responseObserver.onCompleted();
     } catch (StatusRuntimeException e) {
-      logger.error("Getting orders failed", e);
-      abortTransaction(transaction);
+      logger.error("{} failed", funcName, e);
+      rollbackTransaction(transaction);
       responseObserver.onError(e);
     } catch (Exception e) {
-      String message = "Getting orders failed";
+      String message = funcName + " failed";
       logger.error(message, e);
-      abortTransaction(transaction);
+      rollbackTransaction(transaction);
       responseObserver.onError(
           Status.INTERNAL.withDescription(message).withCause(e).asRuntimeException());
     }
   }
 
-  private sample.rpc.Order getOrder(DistributedTransaction transaction, Order order)
+  private sample.rpc.Order getOrder(TwoPhaseCommitTransaction transaction, Order order)
       throws CrudException {
     // Get the customer name from Customer service
-    String customerName = getCustomerName(order.customerId);
+    String customerName = getCustomerName(transaction.getId(), order.customerId);
 
     sample.rpc.Order.Builder orderBuilder =
         sample.rpc.Order.newBuilder()
@@ -332,10 +315,12 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
     return orderBuilder.setTotal(total).build();
   }
 
-  private String getCustomerName(int customerId) {
+  private String getCustomerName(String transactionId, int customerId) {
     GetCustomerInfoResponse customerInfo =
-        customerServiceStub.getCustomerInfo(
-            GetCustomerInfoRequest.newBuilder().setCustomerId(customerId).build());
+        customerServiceStub.getCustomerInfoInTwoPhaseCommit(
+            GetCustomerInfoRequest.newBuilder()
+                .setTransactionId(transactionId)
+                .setCustomerId(customerId).build());
     return customerInfo.getName();
   }
 

--- a/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -288,7 +288,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfo(sample.rpc.GetCustomerInfoRequest request,
@@ -430,7 +430,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfo(sample.rpc.GetCustomerInfoRequest request,
@@ -525,7 +525,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public sample.rpc.GetCustomerInfoResponse getCustomerInfo(sample.rpc.GetCustomerInfoRequest request) {
@@ -613,7 +613,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfo(

--- a/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -329,7 +329,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
@@ -489,7 +489,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
@@ -594,7 +594,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
@@ -693,7 +693,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(

--- a/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -49,37 +49,6 @@ public final class CustomerServiceGrpc {
     return getGetCustomerInfoMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoForTwoPhaseCommit",
-      requestType = sample.rpc.GetCustomerInfoRequest.class,
-      responseType = sample.rpc.GetCustomerInfoResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod() {
-    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
-    if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
-      synchronized (CustomerServiceGrpc.class) {
-        if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
-          CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod = getGetCustomerInfoForTwoPhaseCommitMethod =
-              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoForTwoPhaseCommit"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoForTwoPhaseCommit"))
-              .build();
-        }
-      }
-    }
-    return getGetCustomerInfoForTwoPhaseCommitMethod;
-  }
-
   private static volatile io.grpc.MethodDescriptor<sample.rpc.RepaymentRequest,
       com.google.protobuf.Empty> getRepaymentMethod;
 
@@ -329,16 +298,6 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoForTwoPhaseCommitMethod(), responseObserver);
-    }
-
-    /**
-     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -406,13 +365,6 @@ public final class CustomerServiceGrpc {
                 sample.rpc.GetCustomerInfoRequest,
                 sample.rpc.GetCustomerInfoResponse>(
                   this, METHODID_GET_CUSTOMER_INFO)))
-          .addMethod(
-            getGetCustomerInfoForTwoPhaseCommitMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                sample.rpc.GetCustomerInfoRequest,
-                sample.rpc.GetCustomerInfoResponse>(
-                  this, METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT)))
           .addMethod(
             getRepaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -485,17 +437,6 @@ public final class CustomerServiceGrpc {
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getGetCustomerInfoMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -594,16 +535,6 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions(), request);
-    }
-
-    /**
-     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -693,17 +624,6 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(
-        sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request);
-    }
-
-    /**
-     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -770,13 +690,12 @@ public final class CustomerServiceGrpc {
   }
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
-  private static final int METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT = 1;
-  private static final int METHODID_REPAYMENT = 2;
-  private static final int METHODID_PAYMENT = 3;
-  private static final int METHODID_PREPARE = 4;
-  private static final int METHODID_VALIDATE = 5;
-  private static final int METHODID_COMMIT = 6;
-  private static final int METHODID_ROLLBACK = 7;
+  private static final int METHODID_REPAYMENT = 1;
+  private static final int METHODID_PAYMENT = 2;
+  private static final int METHODID_PREPARE = 3;
+  private static final int METHODID_VALIDATE = 4;
+  private static final int METHODID_COMMIT = 5;
+  private static final int METHODID_ROLLBACK = 6;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -797,10 +716,6 @@ public final class CustomerServiceGrpc {
       switch (methodId) {
         case METHODID_GET_CUSTOMER_INFO:
           serviceImpl.getCustomerInfo((sample.rpc.GetCustomerInfoRequest) request,
-              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
-          break;
-        case METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT:
-          serviceImpl.getCustomerInfoForTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_REPAYMENT:
@@ -889,7 +804,6 @@ public final class CustomerServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
-              .addMethod(getGetCustomerInfoForTwoPhaseCommitMethod())
               .addMethod(getRepaymentMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())

--- a/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -49,6 +49,37 @@ public final class CustomerServiceGrpc {
     return getGetCustomerInfoMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoForTwoPhaseCommit",
+      requestType = sample.rpc.GetCustomerInfoRequest.class,
+      responseType = sample.rpc.GetCustomerInfoResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod() {
+    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
+    if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
+      synchronized (CustomerServiceGrpc.class) {
+        if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
+          CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod = getGetCustomerInfoForTwoPhaseCommitMethod =
+              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoForTwoPhaseCommit"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoForTwoPhaseCommit"))
+              .build();
+        }
+      }
+    }
+    return getGetCustomerInfoForTwoPhaseCommitMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<sample.rpc.RepaymentRequest,
       com.google.protobuf.Empty> getRepaymentMethod;
 
@@ -78,37 +109,6 @@ public final class CustomerServiceGrpc {
       }
     }
     return getRepaymentMethod;
-  }
-
-  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoInTwoPhaseCommit",
-      requestType = sample.rpc.GetCustomerInfoRequest.class,
-      responseType = sample.rpc.GetCustomerInfoResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod() {
-    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
-    if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
-      synchronized (CustomerServiceGrpc.class) {
-        if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
-          CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod = getGetCustomerInfoInTwoPhaseCommitMethod =
-              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoInTwoPhaseCommit"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoInTwoPhaseCommit"))
-              .build();
-        }
-      }
-    }
-    return getGetCustomerInfoInTwoPhaseCommitMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<sample.rpc.PaymentRequest,
@@ -329,22 +329,22 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoForTwoPhaseCommitMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
     public void repayment(sample.rpc.RepaymentRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getRepaymentMethod(), responseObserver);
-    }
-
-    /**
-     * <pre>
-     * Get a customer information
-     * </pre>
-     */
-    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoInTwoPhaseCommitMethod(), responseObserver);
     }
 
     /**
@@ -407,19 +407,19 @@ public final class CustomerServiceGrpc {
                 sample.rpc.GetCustomerInfoResponse>(
                   this, METHODID_GET_CUSTOMER_INFO)))
           .addMethod(
+            getGetCustomerInfoForTwoPhaseCommitMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                sample.rpc.GetCustomerInfoRequest,
+                sample.rpc.GetCustomerInfoResponse>(
+                  this, METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT)))
+          .addMethod(
             getRepaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
                 sample.rpc.RepaymentRequest,
                 com.google.protobuf.Empty>(
                   this, METHODID_REPAYMENT)))
-          .addMethod(
-            getGetCustomerInfoInTwoPhaseCommitMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                sample.rpc.GetCustomerInfoRequest,
-                sample.rpc.GetCustomerInfoResponse>(
-                  this, METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT)))
           .addMethod(
             getPaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -489,6 +489,17 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -496,17 +507,6 @@ public final class CustomerServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getRepaymentMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     * <pre>
-     * Get a customer information
-     * </pre>
-     */
-    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -594,22 +594,22 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
     public com.google.protobuf.Empty repayment(sample.rpc.RepaymentRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getRepaymentMethod(), getCallOptions(), request);
-    }
-
-    /**
-     * <pre>
-     * Get a customer information
-     * </pre>
-     */
-    public sample.rpc.GetCustomerInfoResponse getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions(), request);
     }
 
     /**
@@ -693,6 +693,17 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(
+        sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -700,17 +711,6 @@ public final class CustomerServiceGrpc {
         sample.rpc.RepaymentRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getRepaymentMethod(), getCallOptions()), request);
-    }
-
-    /**
-     * <pre>
-     * Get a customer information
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoInTwoPhaseCommit(
-        sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request);
     }
 
     /**
@@ -770,8 +770,8 @@ public final class CustomerServiceGrpc {
   }
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
-  private static final int METHODID_REPAYMENT = 1;
-  private static final int METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT = 2;
+  private static final int METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT = 1;
+  private static final int METHODID_REPAYMENT = 2;
   private static final int METHODID_PAYMENT = 3;
   private static final int METHODID_PREPARE = 4;
   private static final int METHODID_VALIDATE = 5;
@@ -799,13 +799,13 @@ public final class CustomerServiceGrpc {
           serviceImpl.getCustomerInfo((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
+        case METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT:
+          serviceImpl.getCustomerInfoForTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
+              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
+          break;
         case METHODID_REPAYMENT:
           serviceImpl.repayment((sample.rpc.RepaymentRequest) request,
               (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
-          break;
-        case METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT:
-          serviceImpl.getCustomerInfoInTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
-              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_PAYMENT:
           serviceImpl.payment((sample.rpc.PaymentRequest) request,
@@ -889,8 +889,8 @@ public final class CustomerServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
+              .addMethod(getGetCustomerInfoForTwoPhaseCommitMethod())
               .addMethod(getRepaymentMethod())
-              .addMethod(getGetCustomerInfoInTwoPhaseCommitMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())
               .addMethod(getValidateMethod())

--- a/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -80,6 +80,37 @@ public final class CustomerServiceGrpc {
     return getRepaymentMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoInTwoPhaseCommit",
+      requestType = sample.rpc.GetCustomerInfoRequest.class,
+      responseType = sample.rpc.GetCustomerInfoResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod() {
+    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
+    if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
+      synchronized (CustomerServiceGrpc.class) {
+        if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
+          CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod = getGetCustomerInfoInTwoPhaseCommitMethod =
+              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoInTwoPhaseCommit"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoInTwoPhaseCommit"))
+              .build();
+        }
+      }
+    }
+    return getGetCustomerInfoInTwoPhaseCommitMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<sample.rpc.PaymentRequest,
       com.google.protobuf.Empty> getPaymentMethod;
 
@@ -308,6 +339,16 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoInTwoPhaseCommitMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Credit card payment
      * </pre>
      */
@@ -372,6 +413,13 @@ public final class CustomerServiceGrpc {
                 sample.rpc.RepaymentRequest,
                 com.google.protobuf.Empty>(
                   this, METHODID_REPAYMENT)))
+          .addMethod(
+            getGetCustomerInfoInTwoPhaseCommitMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                sample.rpc.GetCustomerInfoRequest,
+                sample.rpc.GetCustomerInfoResponse>(
+                  this, METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT)))
           .addMethod(
             getPaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -448,6 +496,17 @@ public final class CustomerServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getRepaymentMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -545,6 +604,16 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public sample.rpc.GetCustomerInfoResponse getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Credit card payment
      * </pre>
      */
@@ -635,6 +704,17 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoInTwoPhaseCommit(
+        sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Credit card payment
      * </pre>
      */
@@ -691,11 +771,12 @@ public final class CustomerServiceGrpc {
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
   private static final int METHODID_REPAYMENT = 1;
-  private static final int METHODID_PAYMENT = 2;
-  private static final int METHODID_PREPARE = 3;
-  private static final int METHODID_VALIDATE = 4;
-  private static final int METHODID_COMMIT = 5;
-  private static final int METHODID_ROLLBACK = 6;
+  private static final int METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT = 2;
+  private static final int METHODID_PAYMENT = 3;
+  private static final int METHODID_PREPARE = 4;
+  private static final int METHODID_VALIDATE = 5;
+  private static final int METHODID_COMMIT = 6;
+  private static final int METHODID_ROLLBACK = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -721,6 +802,10 @@ public final class CustomerServiceGrpc {
         case METHODID_REPAYMENT:
           serviceImpl.repayment((sample.rpc.RepaymentRequest) request,
               (io.grpc.stub.StreamObserver<com.google.protobuf.Empty>) responseObserver);
+          break;
+        case METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT:
+          serviceImpl.getCustomerInfoInTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
+              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_PAYMENT:
           serviceImpl.payment((sample.rpc.PaymentRequest) request,
@@ -805,6 +890,7 @@ public final class CustomerServiceGrpc {
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
               .addMethod(getRepaymentMethod())
+              .addMethod(getGetCustomerInfoInTwoPhaseCommitMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())
               .addMethod(getValidateMethod())

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequest.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequest.java
@@ -16,6 +16,7 @@ private static final long serialVersionUID = 0L;
     super(builder);
   }
   private GetCustomerInfoRequest() {
+    transactionId_ = "";
   }
 
   @java.lang.Override
@@ -38,10 +39,58 @@ private static final long serialVersionUID = 0L;
             sample.rpc.GetCustomerInfoRequest.class, sample.rpc.GetCustomerInfoRequest.Builder.class);
   }
 
-  public static final int CUSTOMER_ID_FIELD_NUMBER = 1;
+  private int bitField0_;
+  public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object transactionId_ = "";
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return Whether the transactionId field is set.
+   */
+  @java.lang.Override
+  public boolean hasTransactionId() {
+    return ((bitField0_ & 0x00000001) != 0);
+  }
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The transactionId.
+   */
+  @java.lang.Override
+  public java.lang.String getTransactionId() {
+    java.lang.Object ref = transactionId_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs = 
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      transactionId_ = s;
+      return s;
+    }
+  }
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The bytes for transactionId.
+   */
+  @java.lang.Override
+  public com.google.protobuf.ByteString
+      getTransactionIdBytes() {
+    java.lang.Object ref = transactionId_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      transactionId_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
+  public static final int CUSTOMER_ID_FIELD_NUMBER = 2;
   private int customerId_ = 0;
   /**
-   * <code>int32 customer_id = 1;</code>
+   * <code>int32 customer_id = 2;</code>
    * @return The customerId.
    */
   @java.lang.Override
@@ -63,8 +112,11 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
+    if (((bitField0_ & 0x00000001) != 0)) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
+    }
     if (customerId_ != 0) {
-      output.writeInt32(1, customerId_);
+      output.writeInt32(2, customerId_);
     }
     getUnknownFields().writeTo(output);
   }
@@ -75,9 +127,12 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
+    if (((bitField0_ & 0x00000001) != 0)) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
+    }
     if (customerId_ != 0) {
       size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(1, customerId_);
+        .computeInt32Size(2, customerId_);
     }
     size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
@@ -94,6 +149,11 @@ private static final long serialVersionUID = 0L;
     }
     sample.rpc.GetCustomerInfoRequest other = (sample.rpc.GetCustomerInfoRequest) obj;
 
+    if (hasTransactionId() != other.hasTransactionId()) return false;
+    if (hasTransactionId()) {
+      if (!getTransactionId()
+          .equals(other.getTransactionId())) return false;
+    }
     if (getCustomerId()
         != other.getCustomerId()) return false;
     if (!getUnknownFields().equals(other.getUnknownFields())) return false;
@@ -107,6 +167,10 @@ private static final long serialVersionUID = 0L;
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
+    if (hasTransactionId()) {
+      hash = (37 * hash) + TRANSACTION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getTransactionId().hashCode();
+    }
     hash = (37 * hash) + CUSTOMER_ID_FIELD_NUMBER;
     hash = (53 * hash) + getCustomerId();
     hash = (29 * hash) + getUnknownFields().hashCode();
@@ -240,6 +304,7 @@ private static final long serialVersionUID = 0L;
     public Builder clear() {
       super.clear();
       bitField0_ = 0;
+      transactionId_ = "";
       customerId_ = 0;
       return this;
     }
@@ -274,9 +339,15 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(sample.rpc.GetCustomerInfoRequest result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.transactionId_ = transactionId_;
+        to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
         result.customerId_ = customerId_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -291,6 +362,11 @@ private static final long serialVersionUID = 0L;
 
     public Builder mergeFrom(sample.rpc.GetCustomerInfoRequest other) {
       if (other == sample.rpc.GetCustomerInfoRequest.getDefaultInstance()) return this;
+      if (other.hasTransactionId()) {
+        transactionId_ = other.transactionId_;
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       if (other.getCustomerId() != 0) {
         setCustomerId(other.getCustomerId());
       }
@@ -320,11 +396,16 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 8: {
-              customerId_ = input.readInt32();
+            case 10: {
+              transactionId_ = input.readStringRequireUtf8();
               bitField0_ |= 0x00000001;
               break;
-            } // case 8
+            } // case 10
+            case 16: {
+              customerId_ = input.readInt32();
+              bitField0_ |= 0x00000002;
+              break;
+            } // case 16
             default: {
               if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                 done = true; // was an endgroup tag
@@ -342,9 +423,88 @@ private static final long serialVersionUID = 0L;
     }
     private int bitField0_;
 
+    private java.lang.Object transactionId_ = "";
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return Whether the transactionId field is set.
+     */
+    public boolean hasTransactionId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        transactionId_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @param value The transactionId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTransactionId(
+        java.lang.String value) {
+      if (value == null) { throw new NullPointerException(); }
+      transactionId_ = value;
+      bitField0_ |= 0x00000001;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearTransactionId() {
+      transactionId_ = getDefaultInstance().getTransactionId();
+      bitField0_ = (bitField0_ & ~0x00000001);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @param value The bytes for transactionId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTransactionIdBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
+      transactionId_ = value;
+      bitField0_ |= 0x00000001;
+      onChanged();
+      return this;
+    }
+
     private int customerId_ ;
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @return The customerId.
      */
     @java.lang.Override
@@ -352,23 +512,23 @@ private static final long serialVersionUID = 0L;
       return customerId_;
     }
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @param value The customerId to set.
      * @return This builder for chaining.
      */
     public Builder setCustomerId(int value) {
 
       customerId_ = value;
-      bitField0_ |= 0x00000001;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @return This builder for chaining.
      */
     public Builder clearCustomerId() {
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000002);
       customerId_ = 0;
       onChanged();
       return this;

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequestOrBuilder.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequestOrBuilder.java
@@ -8,7 +8,24 @@ public interface GetCustomerInfoRequestOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>int32 customer_id = 1;</code>
+   * <code>optional string transaction_id = 1;</code>
+   * @return Whether the transactionId field is set.
+   */
+  boolean hasTransactionId();
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The transactionId.
+   */
+  java.lang.String getTransactionId();
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The bytes for transactionId.
+   */
+  com.google.protobuf.ByteString
+      getTransactionIdBytes();
+
+  /**
+   * <code>int32 customer_id = 2;</code>
    * @return The customerId.
    */
   int getCustomerId();

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -123,35 +123,37 @@ public final class Sample {
       "\001(\t\"-\n\020GetOrderResponse\022\031\n\005order\030\001 \001(\0132\n" +
       ".rpc.Order\"\'\n\020GetOrdersRequest\022\023\n\013custom" +
       "er_id\030\001 \001(\005\".\n\021GetOrdersResponse\022\031\n\005orde" +
-      "r\030\001 \003(\0132\n.rpc.Order\"-\n\026GetCustomerInfoRe" +
-      "quest\022\023\n\013customer_id\030\001 \001(\005\"_\n\027GetCustome" +
-      "rInfoResponse\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030\002 \001(\t\022" +
-      "\024\n\014credit_limit\030\003 \001(\005\022\024\n\014credit_total\030\004 " +
-      "\001(\005\"M\n\016PaymentRequest\022\026\n\016transaction_id\030" +
-      "\001 \001(\t\022\023\n\013customer_id\030\002 \001(\005\022\016\n\006amount\030\003 \001" +
-      "(\005\"7\n\020RepaymentRequest\022\023\n\013customer_id\030\001 " +
-      "\001(\005\022\016\n\006amount\030\002 \001(\005\"(\n\016PrepareRequest\022\026\n" +
-      "\016transaction_id\030\001 \001(\t\")\n\017ValidateRequest" +
-      "\022\026\n\016transaction_id\030\001 \001(\t\"\'\n\rCommitReques" +
-      "t\022\026\n\016transaction_id\030\001 \001(\t\")\n\017RollbackReq" +
-      "uest\022\026\n\016transaction_id\030\001 \001(\t2\310\001\n\014OrderSe" +
-      "rvice\022?\n\nPlaceOrder\022\026.rpc.PlaceOrderRequ" +
-      "est\032\027.rpc.PlaceOrderResponse\"\000\0229\n\010GetOrd" +
-      "er\022\024.rpc.GetOrderRequest\032\025.rpc.GetOrderR" +
-      "esponse\"\000\022<\n\tGetOrders\022\025.rpc.GetOrdersRe" +
-      "quest\032\026.rpc.GetOrdersResponse\"\0002\303\003\n\017Cust" +
-      "omerService\022N\n\017GetCustomerInfo\022\033.rpc.Get" +
-      "CustomerInfoRequest\032\034.rpc.GetCustomerInf" +
-      "oResponse\"\000\022<\n\tRepayment\022\025.rpc.Repayment" +
-      "Request\032\026.google.protobuf.Empty\"\000\0228\n\007Pay" +
-      "ment\022\023.rpc.PaymentRequest\032\026.google.proto" +
-      "buf.Empty\"\000\0228\n\007Prepare\022\023.rpc.PrepareRequ" +
-      "est\032\026.google.protobuf.Empty\"\000\022:\n\010Validat" +
-      "e\022\024.rpc.ValidateRequest\032\026.google.protobu" +
-      "f.Empty\"\000\0226\n\006Commit\022\022.rpc.CommitRequest\032" +
-      "\026.google.protobuf.Empty\"\000\022:\n\010Rollback\022\024." +
-      "rpc.RollbackRequest\032\026.google.protobuf.Em" +
-      "pty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006proto3"
+      "r\030\001 \003(\0132\n.rpc.Order\"]\n\026GetCustomerInfoRe" +
+      "quest\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001\022\023\n\013cu" +
+      "stomer_id\030\002 \001(\005B\021\n\017_transaction_id\"_\n\027Ge" +
+      "tCustomerInfoResponse\022\n\n\002id\030\001 \001(\005\022\014\n\004nam" +
+      "e\030\002 \001(\t\022\024\n\014credit_limit\030\003 \001(\005\022\024\n\014credit_" +
+      "total\030\004 \001(\005\"M\n\016PaymentRequest\022\026\n\016transac" +
+      "tion_id\030\001 \001(\t\022\023\n\013customer_id\030\002 \001(\005\022\016\n\006am" +
+      "ount\030\003 \001(\005\"7\n\020RepaymentRequest\022\023\n\013custom" +
+      "er_id\030\001 \001(\005\022\016\n\006amount\030\002 \001(\005\"(\n\016PrepareRe" +
+      "quest\022\026\n\016transaction_id\030\001 \001(\t\")\n\017Validat" +
+      "eRequest\022\026\n\016transaction_id\030\001 \001(\t\"\'\n\rComm" +
+      "itRequest\022\026\n\016transaction_id\030\001 \001(\t\")\n\017Rol" +
+      "lbackRequest\022\026\n\016transaction_id\030\001 \001(\t2\310\001\n" +
+      "\014OrderService\022?\n\nPlaceOrder\022\026.rpc.PlaceO" +
+      "rderRequest\032\027.rpc.PlaceOrderResponse\"\000\0229" +
+      "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
+      "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
+      "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
+      "\303\003\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
+      "tomerInfoResponse\"\000\022<\n\tRepayment\022\025.rpc.R" +
+      "epaymentRequest\032\026.google.protobuf.Empty\"" +
+      "\000\0228\n\007Payment\022\023.rpc.PaymentRequest\032\026.goog" +
+      "le.protobuf.Empty\"\000\0228\n\007Prepare\022\023.rpc.Pre" +
+      "pareRequest\032\026.google.protobuf.Empty\"\000\022:\n" +
+      "\010Validate\022\024.rpc.ValidateRequest\032\026.google" +
+      ".protobuf.Empty\"\000\0226\n\006Commit\022\022.rpc.Commit" +
+      "Request\032\026.google.protobuf.Empty\"\000\022:\n\010Rol" +
+      "lback\022\024.rpc.RollbackRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006p" +
+      "roto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -217,7 +219,7 @@ public final class Sample {
     internal_static_rpc_GetCustomerInfoRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_rpc_GetCustomerInfoRequest_descriptor,
-        new java.lang.String[] { "CustomerId", });
+        new java.lang.String[] { "TransactionId", "CustomerId", "TransactionId", });
     internal_static_rpc_GetCustomerInfoResponse_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_rpc_GetCustomerInfoResponse_fieldAccessorTable = new

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -141,21 +141,21 @@ public final class Sample {
       "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
       "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
       "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
-      "\243\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      "\244\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
       ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
-      "tomerInfoResponse\"\000\022<\n\tRepayment\022\025.rpc.R" +
-      "epaymentRequest\032\026.google.protobuf.Empty\"" +
-      "\000\022^\n\037GetCustomerInfoInTwoPhaseCommit\022\033.r" +
-      "pc.GetCustomerInfoRequest\032\034.rpc.GetCusto" +
-      "merInfoResponse\"\000\0228\n\007Payment\022\023.rpc.Payme" +
-      "ntRequest\032\026.google.protobuf.Empty\"\000\0228\n\007P" +
-      "repare\022\023.rpc.PrepareRequest\032\026.google.pro" +
-      "tobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validate" +
-      "Request\032\026.google.protobuf.Empty\"\000\0226\n\006Com" +
-      "mit\022\022.rpc.CommitRequest\032\026.google.protobu" +
-      "f.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackRequ" +
-      "est\032\026.google.protobuf.Empty\"\000B\026\n\nsample." +
-      "rpcB\006SampleP\001b\006proto3"
+      "tomerInfoResponse\"\000\022_\n GetCustomerInfoFo" +
+      "rTwoPhaseCommit\022\033.rpc.GetCustomerInfoReq" +
+      "uest\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\t" +
+      "Repayment\022\025.rpc.RepaymentRequest\032\026.googl" +
+      "e.protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Paym" +
+      "entRequest\032\026.google.protobuf.Empty\"\000\0228\n\007" +
+      "Prepare\022\023.rpc.PrepareRequest\032\026.google.pr" +
+      "otobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validat" +
+      "eRequest\032\026.google.protobuf.Empty\"\000\0226\n\006Co" +
+      "mmit\022\022.rpc.CommitRequest\032\026.google.protob" +
+      "uf.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackReq" +
+      "uest\032\026.google.protobuf.Empty\"\000B\026\n\nsample" +
+      ".rpcB\006SampleP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -141,19 +141,21 @@ public final class Sample {
       "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
       "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
       "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
-      "\303\003\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      "\243\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
       ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
       "tomerInfoResponse\"\000\022<\n\tRepayment\022\025.rpc.R" +
       "epaymentRequest\032\026.google.protobuf.Empty\"" +
-      "\000\0228\n\007Payment\022\023.rpc.PaymentRequest\032\026.goog" +
-      "le.protobuf.Empty\"\000\0228\n\007Prepare\022\023.rpc.Pre" +
-      "pareRequest\032\026.google.protobuf.Empty\"\000\022:\n" +
-      "\010Validate\022\024.rpc.ValidateRequest\032\026.google" +
-      ".protobuf.Empty\"\000\0226\n\006Commit\022\022.rpc.Commit" +
-      "Request\032\026.google.protobuf.Empty\"\000\022:\n\010Rol" +
-      "lback\022\024.rpc.RollbackRequest\032\026.google.pro" +
-      "tobuf.Empty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006p" +
-      "roto3"
+      "\000\022^\n\037GetCustomerInfoInTwoPhaseCommit\022\033.r" +
+      "pc.GetCustomerInfoRequest\032\034.rpc.GetCusto" +
+      "merInfoResponse\"\000\0228\n\007Payment\022\023.rpc.Payme" +
+      "ntRequest\032\026.google.protobuf.Empty\"\000\0228\n\007P" +
+      "repare\022\023.rpc.PrepareRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validate" +
+      "Request\032\026.google.protobuf.Empty\"\000\0226\n\006Com" +
+      "mit\022\022.rpc.CommitRequest\032\026.google.protobu" +
+      "f.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackRequ" +
+      "est\032\026.google.protobuf.Empty\"\000B\026\n\nsample." +
+      "rpcB\006SampleP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -141,21 +141,19 @@ public final class Sample {
       "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
       "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
       "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
-      "\244\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      "\303\003\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
       ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
-      "tomerInfoResponse\"\000\022_\n GetCustomerInfoFo" +
-      "rTwoPhaseCommit\022\033.rpc.GetCustomerInfoReq" +
-      "uest\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\t" +
-      "Repayment\022\025.rpc.RepaymentRequest\032\026.googl" +
-      "e.protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Paym" +
-      "entRequest\032\026.google.protobuf.Empty\"\000\0228\n\007" +
-      "Prepare\022\023.rpc.PrepareRequest\032\026.google.pr" +
-      "otobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validat" +
-      "eRequest\032\026.google.protobuf.Empty\"\000\0226\n\006Co" +
-      "mmit\022\022.rpc.CommitRequest\032\026.google.protob" +
-      "uf.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackReq" +
-      "uest\032\026.google.protobuf.Empty\"\000B\026\n\nsample" +
-      ".rpcB\006SampleP\001b\006proto3"
+      "tomerInfoResponse\"\000\022<\n\tRepayment\022\025.rpc.R" +
+      "epaymentRequest\032\026.google.protobuf.Empty\"" +
+      "\000\0228\n\007Payment\022\023.rpc.PaymentRequest\032\026.goog" +
+      "le.protobuf.Empty\"\000\0228\n\007Prepare\022\023.rpc.Pre" +
+      "pareRequest\032\026.google.protobuf.Empty\"\000\022:\n" +
+      "\010Validate\022\024.rpc.ValidateRequest\032\026.google" +
+      ".protobuf.Empty\"\000\0226\n\006Commit\022\022.rpc.Commit" +
+      "Request\032\026.google.protobuf.Empty\"\000\022:\n\010Rol" +
+      "lback\022\024.rpc.RollbackRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006p" +
+      "roto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -97,7 +97,8 @@ service CustomerService {
 }
 
 message GetCustomerInfoRequest {
-  int32 customer_id = 1;
+  optional string transaction_id = 1;
+  int32 customer_id = 2;
 }
 
 message GetCustomerInfoResponse {

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,9 +73,6 @@ service CustomerService {
   // Get customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
-  // Get customer information
-  rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
-  }
   // Credit card repayment
   rpc Repayment(RepaymentRequest) returns (google.protobuf.Empty) {
   }

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,15 +73,15 @@ service CustomerService {
   // Get a customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
+  // Get a customer information
+  rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
+  }
   // Credit card repayment
   rpc Repayment(RepaymentRequest) returns (google.protobuf.Empty) {
   }
 
   // RPCs for two-phase commit transactions
 
-  // Get a customer information
-  rpc GetCustomerInfoInTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
-  }
   // Credit card payment
   rpc Payment(PaymentRequest) returns (google.protobuf.Empty) {
   }

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -79,6 +79,9 @@ service CustomerService {
 
   // RPCs for two-phase commit transactions
 
+  // Get a customer information
+  rpc GetCustomerInfoInTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
+  }
   // Credit card payment
   rpc Payment(PaymentRequest) returns (google.protobuf.Empty) {
   }

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -70,7 +70,7 @@ message GetOrdersResponse {
 
 // for Customer Service
 service CustomerService {
-  // Get a customer information
+  // Get customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Get customer information

--- a/microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,7 +73,7 @@ service CustomerService {
   // Get a customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
-  // Get a customer information
+  // Get customer information
   rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Credit card repayment

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -139,8 +139,8 @@ The sample application supports the following types of transactions:
 - Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
-- Get order information by customer ID through the `getOrders` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -144,6 +144,8 @@ The sample application supports the following types of transactions:
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
+Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. We intentionally separated the endpoints to keep them simple as a sample application.
+
 ## Configuration
 
 [The configuration for the Customer Service](customer-service/src/main/resources/application.properties) is as follows:

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -144,7 +144,13 @@ The sample application supports the following types of transactions:
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
-Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. We intentionally separated the endpoints to keep them simple as a sample application.
+{% capture notice--info %}
+**Note**
+
+Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. The endpoints are intentionally separated for the sake of simplifying them in the sample application.
+{% endcapture %}
+
+<div class="notice--info">{{ notice--info | markdownify }}</div>
 
 ## Configuration
 

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -112,44 +112,37 @@ The Entity Relationship Diagram for the schema is as follows:
 
 ![ERD](images/ERD.png)
 
-### Transactions
-
-The following five transactions are implemented in this sample application:
-
-1. Getting customer information. It is a transaction in the Customer Service
-2. Placing an order (checks if the cost of the order is below the credit limit, then records order history and updates the `credit_total` if the check passes). It is a transaction that spans the Order Service and the Customer Service.
-3. Getting order information by order ID. It is a transaction in the Order Service
-4. Getting order information by customer ID. It is a transaction in the Order Service
-5. Repayment (reduces the amount in the `credit_total`). It is a transaction in the Customer Service.
-
-### Service Endpoints
+### Service endpoints
 
 The endpoints defined in the services are as follows:
 
-Customer Service:
+- Customer Service
+  - `getCustomerInfo`
+  - `getCustomerInfoForTwoPhaseCommit`
+  - `payment`
+  - `prepare`
+  - `validate`
+  - `commit`
+  - `rollback`
+  - `repayment`
 
-- getCustomerInfo
-- payment
-- prepare
-- validate
-- commit
-- rollback
-- repayment
+- Order Service
+  - `placeOrder`
+  - `getOrder`
+  - `getOrders`
 
-Order Service:
+### What you can do in this sample application
 
-- placeOrder
-- getOrder
-- getOrders
+The sample application supports the following types of transactions:
 
-The `getCustomerInfo` endpoint of the Customer Service is for transaction #1 (Getting customer information).
-
-And the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service are for transaction #2 (Placing an order) that spans the Order Service and the Customer Service.
-The Order Service starts the transaction with the `placeOrder` endpoint, which calls the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
-
-The `getOrder` of the Order Service is for transaction #3, and The `getOrders` of the Order Service is for transaction #4.
-
-And the `repayment` endpoint of the Customer Service is for transaction #5.
+- Get customer information through the `getCustomerInfo` endpoint of the Customer Service.
+- Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+  - Checks if the cost of the order is below the customer's credit limit.
+  - If the check passes, records the order history and updates the amount the customer has spent.
+- Get order information by order ID through the `getOrder` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` of the Order Service and `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Make a payment through the `repayment` endpoint of the Customer Service.
+  - Reduces the amount the customer has spent.
 
 ## Configuration
 

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -118,7 +118,6 @@ The endpoints defined in the services are as follows:
 
 - Customer Service
   - `getCustomerInfo`
-  - `getCustomerInfoForTwoPhaseCommit`
   - `payment`
   - `prepare`
   - `validate`
@@ -139,15 +138,16 @@ The sample application supports the following types of transactions:
 - Place an order by using a line of credit through the `placeOrder` endpoint of the Order Service and the `payment`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
   - Checks if the cost of the order is below the customer's credit limit.
   - If the check passes, records the order history and updates the amount the customer has spent.
-- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
-- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfoForTwoPhaseCommit`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by order ID through the `getOrder` endpoint of the Order Service and the `getCustomerInfo`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
+- Get order information by customer ID through the `getOrders` endpoint of the Order Service and the `getCustomerInfo`, `prepare`, `validate`, `commit`, and `rollback` endpoints of the Customer Service.
 - Make a payment through the `repayment` endpoint of the Customer Service.
   - Reduces the amount the customer has spent.
 
 {% capture notice--info %}
 **Note**
 
-Merging the `getCustomerInfoForTwoPhaseCommit` endpoint into the `getCustomerInfo` endpoint may be a good way to reduce the number of endpoints in the Customer Service. The endpoints are intentionally separated for the sake of simplifying them in the sample application.
+The `getCustomerInfo` endpoint works as a participant service endpoint when receiving a transaction ID from the coordinator.
+
 {% endcapture %}
 
 <div class="notice--info">{{ notice--info | markdownify }}</div>

--- a/spring-data-microservice-transaction-sample/README.md
+++ b/spring-data-microservice-transaction-sample/README.md
@@ -374,7 +374,7 @@ $ docker-compose down
 
 ## Reference - How the microservice transaction is achieved
 
-The transactions for placing an order, getting an order and getting orders achieve the microservice transaction, so this section focuses on how the transactions that span the Customer Service and the Order Service are implemented by taking placing an order as an example.
+The transactions for placing an order, getting a single order, and getting the history of orders achieve the microservice transaction. This section focuses on how the transactions that span the Customer Service and the Order Service are implemented by placing an order as an example.
 
 The following sequence diagram shows the transaction for placing an order:
 
@@ -393,7 +393,7 @@ TwoPcResult<String> result = orderRepository.executeTwoPcTransaction(txId -> {
 }, ...);
 ```
 
-The following `CRUD operations are executed`, `Transaction is committed by using the two-phase commit protocol` and `Error handling` are automatically performed by the API.
+The actions in [CRUD operations are executed](#2-crud-operations-are-executed), [Transaction is committed by using the two-phase commit protocol](#3-transaction-is-committed-by-using-the-two-phase-commit-protocol), and [Error handling](#error-handling) are automatically performed by the API.
 
 ### 2. CRUD operations are executed
 
@@ -465,7 +465,7 @@ customerRepository.update(customer.withCreditTotal(updatedCreditTotal));
 
 After the Order Service receives the update that the payment succeeded, the Order Service tries to commit the transaction.
 
-`ScalarDbTwoPcRepository.executeTwoPcTransaction()` API, called on the Order Service, automatically performs preparations, validations and commits of both the local Order Service and the remote Customer Service. These steps are executed sequentially after the above CRUD operations successfully finish. The implementations to invoke `prepare`, `validate` and `commit` gRPC endpoints of the Customer Service need to be passed as parameters to the API. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
+The `ScalarDbTwoPcRepository.executeTwoPcTransaction()` API, which called on the Order Service, automatically performs preparations, validations, and commits of both the local Order Service and the remote Customer Service. These steps are executed sequentially after the above CRUD operations successfully finish. The implementations to invoke `prepare`, `validate`, and `commit` gRPC endpoints of the Customer Service need to be passed as parameters to the API. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 TwoPcResult<PlaceOrderResponse> result = orderRepository.executeTwoPcTransaction(txId ->{
@@ -485,19 +485,19 @@ TwoPcResult<PlaceOrderResponse> result = orderRepository.executeTwoPcTransaction
 
 ![Sequence Diagram of High Level 2PC API](images/seq-diagram-high-level-2pc-api.png)
 
-In the `prepare` endpoint of the Customer Service, it resumes and prepares the transaction with `ScalarDbTwoPcRepository.prepareTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
+In the `prepare` endpoint of the Customer Service, the endpoint resumes and prepares the transaction by using `ScalarDbTwoPcRepository.prepareTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 customerRepository.prepareTransactionOnParticipant(request.getTransactionId());
 ```
 
-In the `validate` endpoint of the Customer Service, it resumes and validates the transaction with `ScalarDbTwoPcRepository.validateTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
+In the `validate` endpoint of the Customer Service, the endpoint resumes and validates the transaction by using `ScalarDbTwoPcRepository.validateTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 customerRepository.validateTransactionOnParticipant(request.getTransactionId());
 ```
 
-In the `commit` endpoint of the Customer Service, it resumes and commits the transaction with `ScalarDbTwoPcRepository.commitTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
+In the `commit` endpoint of the Customer Service, the endpoint resumes and commits the transaction by using `ScalarDbTwoPcRepository.commitTransactionOnParticipant()`. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 customerRepository.commitTransactionOnParticipant(request.getTransactionId());
@@ -505,7 +505,7 @@ customerRepository.commitTransactionOnParticipant(request.getTransactionId());
 
 ### Error handling
 
-If an error happens while executing a transaction, the transaction will be automatically rolled back in both the local Order Service and the remote Customer Service by `ScalarDbTwoPcRepository.executeTwoPcTransaction()`. The implementation to invoke the `rollback` gRPC endpoint of the Customer Service also needs to be passed as a parameter to the API with other ones. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
+If an error happens while executing a transaction, `ScalarDbTwoPcRepository.executeTwoPcTransaction()` will automatically roll back the transaction in both the local Order Service and the remote Customer Service. The implementation to invoke the `rollback` gRPC endpoint of the Customer Service also needs to be passed as a parameter to the API with other ones. For reference, see [`OrderService.java`](order-service/src/main/java/sample/order/OrderService.java).
 
 ```java
 TwoPcResult<PlaceOrderResponse> result = orderRepository.executeTwoPcTransaction(txId ->{
@@ -523,7 +523,7 @@ TwoPcResult<PlaceOrderResponse> result = orderRepository.executeTwoPcTransaction
 );
 ```
 
-In the `rollback` endpoint of the Customer Service, it resumes and rolls back the transaction. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
+In the `rollback` endpoint of the Customer Service, the endpoint resumes and rolls back the transaction. For reference, see [`CustomerService.java`](customer-service/src/main/java/sample/customer/CustomerService.java).
 
 ```java
 customerRepository.rollbackTransactionOnParticipant(request.getTransactionId());

--- a/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -75,7 +75,7 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
   // @Retryable shouldn't be used here as this is used as a participant API and
   // will be retried by the coordinator service if needed
   @Override
-  public void getCustomerInfoInTwoPhaseCommit(
+  public void getCustomerInfoForTwoPhaseCommit(
       GetCustomerInfoRequest request, StreamObserver<GetCustomerInfoResponse> responseObserver) {
     execAndReturnResponse(responseObserver, "Getting customer info", () ->
         customerRepository.joinTransactionOnParticipant(request.getTransactionId(), () -> {

--- a/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/spring-data-microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -62,7 +62,7 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     String funcName = "Getting customer info";
     // This function processing operations can be used in both normal transaction and two-phase
     // interface transaction.
-    Supplier<GetCustomerInfoResponse> task = () -> {
+    Supplier<GetCustomerInfoResponse> operations = () -> {
       Customer customer = getCustomer(responseObserver, request.getCustomerId());
 
       return GetCustomerInfoResponse.newBuilder()
@@ -75,11 +75,11 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
 
     if (request.hasTransactionId()) {
       execAndReturnResponse(funcName,
-          () -> customerRepository.joinTransactionOnParticipant(request.getTransactionId(), task),
+          () -> customerRepository.joinTransactionOnParticipant(request.getTransactionId(), operations),
           responseObserver);
     } else {
       execAndReturnResponse(funcName,
-          () -> customerRepository.executeOneshotOperations(task),
+          () -> customerRepository.executeOneshotOperations(operations),
           responseObserver);
     }
   }
@@ -203,10 +203,10 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
     return null;
   }
 
-  private <T> void execAndReturnResponse(String funcName, Supplier<T> task,
+  private <T> void execAndReturnResponse(String funcName, Supplier<T> operations,
       StreamObserver<T> responseObserver) {
     try {
-      T result = task.get();
+      T result = operations.get();
 
       responseObserver.onNext(result);
       responseObserver.onCompleted();

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -222,7 +222,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   @Override
   public void getOrders(
       GetOrdersRequest request, StreamObserver<GetOrdersResponse> responseObserver) {
-    execAndReturnResponse(responseObserver, "Getting an order", () -> {
+    execAndReturnResponse(responseObserver, "Getting orders", () -> {
       // Start a two-phase commit transaction
       TwoPcResult<GetOrdersResponse> result = orderRepository.executeTwoPcTransaction(txId -> {
             // Get the customer name from Customer service

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -98,7 +98,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
       PlaceOrderRequest request, StreamObserver<PlaceOrderResponse> responseObserver) {
 
     execAndReturnResponse("Placing an order", () -> {
-      // Start a two-phase commit transaction
+      // Start a two-phase commit interface transaction
       TwoPcResult<PlaceOrderResponse> result = orderRepository.executeTwoPcTransaction(txId -> {
             String orderId = UUID.randomUUID().toString();
             Order order = new Order(orderId, request.getCustomerId(), System.currentTimeMillis());
@@ -181,7 +181,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   @Override
   public void getOrder(GetOrderRequest request, StreamObserver<GetOrderResponse> responseObserver) {
     execAndReturnResponse("Getting an order", () -> {
-      // Start a two-phase commit transaction
+      // Start a two-phase commit interface transaction
       TwoPcResult<GetOrderResponse> result = orderRepository.executeTwoPcTransaction(txId -> {
             // Retrieve the order info for the specified order ID
             Optional<Order> orderOpt = orderRepository.findById(request.getOrderId());
@@ -192,7 +192,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
               throw new ScalarDbNonTransientException(message);
             }
 
-            // Get the customer name from Customer service
+            // Get the customer name from the Customer service
             String customerName = getCustomerName(txId, orderOpt.get().customerId);
 
             // Make an order protobuf to return
@@ -223,9 +223,9 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
   public void getOrders(
       GetOrdersRequest request, StreamObserver<GetOrdersResponse> responseObserver) {
     execAndReturnResponse("Getting orders", () -> {
-      // Start a two-phase commit transaction
+      // Start a two-phase commit interface transaction
       TwoPcResult<GetOrdersResponse> result = orderRepository.executeTwoPcTransaction(txId -> {
-            // Get the customer name from Customer service
+            // Get the customer name from the Customer service
             String customerName = getCustomerName(txId, request.getCustomerId());
 
             // Retrieve the order info for the specified order ID
@@ -314,10 +314,10 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
     return null;
   }
 
-  private <T> void execAndReturnResponse(String funcName, Supplier<T> task,
+  private <T> void execAndReturnResponse(String funcName, Supplier<T> operations,
       StreamObserver<T> responseObserver) {
     try {
-      T result = task.get();
+      T result = operations.get();
 
       responseObserver.onNext(result);
       responseObserver.onCompleted();

--- a/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/spring-data-microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -295,7 +295,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
 
   private String getCustomerName(String transactionId, int customerId) {
     GetCustomerInfoResponse customerInfo =
-        stub.getCustomerInfoInTwoPhaseCommit(
+        stub.getCustomerInfoForTwoPhaseCommit(
             GetCustomerInfoRequest.newBuilder()
                 .setTransactionId(transactionId)
                 .setCustomerId(customerId).build());

--- a/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -49,37 +49,6 @@ public final class CustomerServiceGrpc {
     return getGetCustomerInfoMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
-
-  @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoForTwoPhaseCommit",
-      requestType = sample.rpc.GetCustomerInfoRequest.class,
-      responseType = sample.rpc.GetCustomerInfoResponse.class,
-      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod() {
-    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
-    if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
-      synchronized (CustomerServiceGrpc.class) {
-        if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
-          CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod = getGetCustomerInfoForTwoPhaseCommitMethod =
-              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
-              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoForTwoPhaseCommit"))
-              .setSampledToLocalTracing(true)
-              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
-              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoForTwoPhaseCommit"))
-              .build();
-        }
-      }
-    }
-    return getGetCustomerInfoForTwoPhaseCommitMethod;
-  }
-
   private static volatile io.grpc.MethodDescriptor<sample.rpc.RepaymentRequest,
       com.google.protobuf.Empty> getRepaymentMethod;
 
@@ -319,22 +288,12 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfo(sample.rpc.GetCustomerInfoRequest request,
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoMethod(), responseObserver);
-    }
-
-    /**
-     * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoForTwoPhaseCommitMethod(), responseObserver);
     }
 
     /**
@@ -407,13 +366,6 @@ public final class CustomerServiceGrpc {
                 sample.rpc.GetCustomerInfoResponse>(
                   this, METHODID_GET_CUSTOMER_INFO)))
           .addMethod(
-            getGetCustomerInfoForTwoPhaseCommitMethod(),
-            io.grpc.stub.ServerCalls.asyncUnaryCall(
-              new MethodHandlers<
-                sample.rpc.GetCustomerInfoRequest,
-                sample.rpc.GetCustomerInfoResponse>(
-                  this, METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT)))
-          .addMethod(
             getRepaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
@@ -478,24 +430,13 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfo(sample.rpc.GetCustomerInfoRequest request,
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getGetCustomerInfoMethod(), getCallOptions()), request, responseObserver);
-    }
-
-    /**
-     * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
-        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -584,22 +525,12 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public sample.rpc.GetCustomerInfoResponse getCustomerInfo(sample.rpc.GetCustomerInfoRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getGetCustomerInfoMethod(), getCallOptions(), request);
-    }
-
-    /**
-     * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions(), request);
     }
 
     /**
@@ -682,24 +613,13 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfo(
         sample.rpc.GetCustomerInfoRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getGetCustomerInfoMethod(), getCallOptions()), request);
-    }
-
-    /**
-     * <pre>
-     * Get customer information
-     * </pre>
-     */
-    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(
-        sample.rpc.GetCustomerInfoRequest request) {
-      return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request);
     }
 
     /**
@@ -770,13 +690,12 @@ public final class CustomerServiceGrpc {
   }
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
-  private static final int METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT = 1;
-  private static final int METHODID_REPAYMENT = 2;
-  private static final int METHODID_PAYMENT = 3;
-  private static final int METHODID_PREPARE = 4;
-  private static final int METHODID_VALIDATE = 5;
-  private static final int METHODID_COMMIT = 6;
-  private static final int METHODID_ROLLBACK = 7;
+  private static final int METHODID_REPAYMENT = 1;
+  private static final int METHODID_PAYMENT = 2;
+  private static final int METHODID_PREPARE = 3;
+  private static final int METHODID_VALIDATE = 4;
+  private static final int METHODID_COMMIT = 5;
+  private static final int METHODID_ROLLBACK = 6;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -797,10 +716,6 @@ public final class CustomerServiceGrpc {
       switch (methodId) {
         case METHODID_GET_CUSTOMER_INFO:
           serviceImpl.getCustomerInfo((sample.rpc.GetCustomerInfoRequest) request,
-              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
-          break;
-        case METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT:
-          serviceImpl.getCustomerInfoForTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_REPAYMENT:
@@ -889,7 +804,6 @@ public final class CustomerServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
-              .addMethod(getGetCustomerInfoForTwoPhaseCommitMethod())
               .addMethod(getRepaymentMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())

--- a/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -50,34 +50,34 @@ public final class CustomerServiceGrpc {
   }
 
   private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
-      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoInTwoPhaseCommit",
+      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoForTwoPhaseCommit",
       requestType = sample.rpc.GetCustomerInfoRequest.class,
       responseType = sample.rpc.GetCustomerInfoResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
-      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod() {
-    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
-    if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod() {
+    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoForTwoPhaseCommitMethod;
+    if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
       synchronized (CustomerServiceGrpc.class) {
-        if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
-          CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod = getGetCustomerInfoInTwoPhaseCommitMethod =
+        if ((getGetCustomerInfoForTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod) == null) {
+          CustomerServiceGrpc.getGetCustomerInfoForTwoPhaseCommitMethod = getGetCustomerInfoForTwoPhaseCommitMethod =
               io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoInTwoPhaseCommit"))
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoForTwoPhaseCommit"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
                   sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
                   sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
-              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoInTwoPhaseCommit"))
+              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoForTwoPhaseCommit"))
               .build();
         }
       }
     }
-    return getGetCustomerInfoInTwoPhaseCommitMethod;
+    return getGetCustomerInfoForTwoPhaseCommitMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<sample.rpc.RepaymentRequest,
@@ -332,9 +332,9 @@ public final class CustomerServiceGrpc {
      * Get a customer information
      * </pre>
      */
-    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
-      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoInTwoPhaseCommitMethod(), responseObserver);
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoForTwoPhaseCommitMethod(), responseObserver);
     }
 
     /**
@@ -407,12 +407,12 @@ public final class CustomerServiceGrpc {
                 sample.rpc.GetCustomerInfoResponse>(
                   this, METHODID_GET_CUSTOMER_INFO)))
           .addMethod(
-            getGetCustomerInfoInTwoPhaseCommitMethod(),
+            getGetCustomerInfoForTwoPhaseCommitMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
                 sample.rpc.GetCustomerInfoRequest,
                 sample.rpc.GetCustomerInfoResponse>(
-                  this, METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT)))
+                  this, METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT)))
           .addMethod(
             getRepaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -492,10 +492,10 @@ public final class CustomerServiceGrpc {
      * Get a customer information
      * </pre>
      */
-    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+    public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
-          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
+          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -597,9 +597,9 @@ public final class CustomerServiceGrpc {
      * Get a customer information
      * </pre>
      */
-    public sample.rpc.GetCustomerInfoResponse getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
+    public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
-          getChannel(), getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions(), request);
+          getChannel(), getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions(), request);
     }
 
     /**
@@ -696,10 +696,10 @@ public final class CustomerServiceGrpc {
      * Get a customer information
      * </pre>
      */
-    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoInTwoPhaseCommit(
+    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(
         sample.rpc.GetCustomerInfoRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
-          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request);
+          getChannel().newCall(getGetCustomerInfoForTwoPhaseCommitMethod(), getCallOptions()), request);
     }
 
     /**
@@ -770,7 +770,7 @@ public final class CustomerServiceGrpc {
   }
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
-  private static final int METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT = 1;
+  private static final int METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT = 1;
   private static final int METHODID_REPAYMENT = 2;
   private static final int METHODID_PAYMENT = 3;
   private static final int METHODID_PREPARE = 4;
@@ -799,8 +799,8 @@ public final class CustomerServiceGrpc {
           serviceImpl.getCustomerInfo((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
-        case METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT:
-          serviceImpl.getCustomerInfoInTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
+        case METHODID_GET_CUSTOMER_INFO_FOR_TWO_PHASE_COMMIT:
+          serviceImpl.getCustomerInfoForTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_REPAYMENT:
@@ -889,7 +889,7 @@ public final class CustomerServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
-              .addMethod(getGetCustomerInfoInTwoPhaseCommitMethod())
+              .addMethod(getGetCustomerInfoForTwoPhaseCommitMethod())
               .addMethod(getRepaymentMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())

--- a/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -329,7 +329,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
@@ -489,7 +489,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public void getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
@@ -594,7 +594,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public sample.rpc.GetCustomerInfoResponse getCustomerInfoForTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
@@ -693,7 +693,7 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
-     * Get a customer information
+     * Get customer information
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoForTwoPhaseCommit(

--- a/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/grpc/sample/rpc/CustomerServiceGrpc.java
@@ -49,6 +49,37 @@ public final class CustomerServiceGrpc {
     return getGetCustomerInfoMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetCustomerInfoInTwoPhaseCommit",
+      requestType = sample.rpc.GetCustomerInfoRequest.class,
+      responseType = sample.rpc.GetCustomerInfoResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest,
+      sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod() {
+    io.grpc.MethodDescriptor<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse> getGetCustomerInfoInTwoPhaseCommitMethod;
+    if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
+      synchronized (CustomerServiceGrpc.class) {
+        if ((getGetCustomerInfoInTwoPhaseCommitMethod = CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod) == null) {
+          CustomerServiceGrpc.getGetCustomerInfoInTwoPhaseCommitMethod = getGetCustomerInfoInTwoPhaseCommitMethod =
+              io.grpc.MethodDescriptor.<sample.rpc.GetCustomerInfoRequest, sample.rpc.GetCustomerInfoResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetCustomerInfoInTwoPhaseCommit"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  sample.rpc.GetCustomerInfoResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new CustomerServiceMethodDescriptorSupplier("GetCustomerInfoInTwoPhaseCommit"))
+              .build();
+        }
+      }
+    }
+    return getGetCustomerInfoInTwoPhaseCommitMethod;
+  }
+
   private static volatile io.grpc.MethodDescriptor<sample.rpc.RepaymentRequest,
       com.google.protobuf.Empty> getRepaymentMethod;
 
@@ -298,6 +329,16 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getGetCustomerInfoInTwoPhaseCommitMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -365,6 +406,13 @@ public final class CustomerServiceGrpc {
                 sample.rpc.GetCustomerInfoRequest,
                 sample.rpc.GetCustomerInfoResponse>(
                   this, METHODID_GET_CUSTOMER_INFO)))
+          .addMethod(
+            getGetCustomerInfoInTwoPhaseCommitMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                sample.rpc.GetCustomerInfoRequest,
+                sample.rpc.GetCustomerInfoResponse>(
+                  this, METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT)))
           .addMethod(
             getRepaymentMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -437,6 +485,17 @@ public final class CustomerServiceGrpc {
         io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getGetCustomerInfoMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public void getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request,
+        io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -535,6 +594,16 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public sample.rpc.GetCustomerInfoResponse getCustomerInfoInTwoPhaseCommit(sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -624,6 +693,17 @@ public final class CustomerServiceGrpc {
 
     /**
      * <pre>
+     * Get a customer information
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<sample.rpc.GetCustomerInfoResponse> getCustomerInfoInTwoPhaseCommit(
+        sample.rpc.GetCustomerInfoRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getGetCustomerInfoInTwoPhaseCommitMethod(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Credit card repayment
      * </pre>
      */
@@ -690,12 +770,13 @@ public final class CustomerServiceGrpc {
   }
 
   private static final int METHODID_GET_CUSTOMER_INFO = 0;
-  private static final int METHODID_REPAYMENT = 1;
-  private static final int METHODID_PAYMENT = 2;
-  private static final int METHODID_PREPARE = 3;
-  private static final int METHODID_VALIDATE = 4;
-  private static final int METHODID_COMMIT = 5;
-  private static final int METHODID_ROLLBACK = 6;
+  private static final int METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT = 1;
+  private static final int METHODID_REPAYMENT = 2;
+  private static final int METHODID_PAYMENT = 3;
+  private static final int METHODID_PREPARE = 4;
+  private static final int METHODID_VALIDATE = 5;
+  private static final int METHODID_COMMIT = 6;
+  private static final int METHODID_ROLLBACK = 7;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -716,6 +797,10 @@ public final class CustomerServiceGrpc {
       switch (methodId) {
         case METHODID_GET_CUSTOMER_INFO:
           serviceImpl.getCustomerInfo((sample.rpc.GetCustomerInfoRequest) request,
+              (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
+          break;
+        case METHODID_GET_CUSTOMER_INFO_IN_TWO_PHASE_COMMIT:
+          serviceImpl.getCustomerInfoInTwoPhaseCommit((sample.rpc.GetCustomerInfoRequest) request,
               (io.grpc.stub.StreamObserver<sample.rpc.GetCustomerInfoResponse>) responseObserver);
           break;
         case METHODID_REPAYMENT:
@@ -804,6 +889,7 @@ public final class CustomerServiceGrpc {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new CustomerServiceFileDescriptorSupplier())
               .addMethod(getGetCustomerInfoMethod())
+              .addMethod(getGetCustomerInfoInTwoPhaseCommitMethod())
               .addMethod(getRepaymentMethod())
               .addMethod(getPaymentMethod())
               .addMethod(getPrepareMethod())

--- a/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequest.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequest.java
@@ -16,6 +16,7 @@ private static final long serialVersionUID = 0L;
     super(builder);
   }
   private GetCustomerInfoRequest() {
+    transactionId_ = "";
   }
 
   @java.lang.Override
@@ -38,10 +39,58 @@ private static final long serialVersionUID = 0L;
             sample.rpc.GetCustomerInfoRequest.class, sample.rpc.GetCustomerInfoRequest.Builder.class);
   }
 
-  public static final int CUSTOMER_ID_FIELD_NUMBER = 1;
+  private int bitField0_;
+  public static final int TRANSACTION_ID_FIELD_NUMBER = 1;
+  @SuppressWarnings("serial")
+  private volatile java.lang.Object transactionId_ = "";
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return Whether the transactionId field is set.
+   */
+  @java.lang.Override
+  public boolean hasTransactionId() {
+    return ((bitField0_ & 0x00000001) != 0);
+  }
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The transactionId.
+   */
+  @java.lang.Override
+  public java.lang.String getTransactionId() {
+    java.lang.Object ref = transactionId_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs = 
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      transactionId_ = s;
+      return s;
+    }
+  }
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The bytes for transactionId.
+   */
+  @java.lang.Override
+  public com.google.protobuf.ByteString
+      getTransactionIdBytes() {
+    java.lang.Object ref = transactionId_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b = 
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      transactionId_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
+  public static final int CUSTOMER_ID_FIELD_NUMBER = 2;
   private int customerId_ = 0;
   /**
-   * <code>int32 customer_id = 1;</code>
+   * <code>int32 customer_id = 2;</code>
    * @return The customerId.
    */
   @java.lang.Override
@@ -63,8 +112,11 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
+    if (((bitField0_ & 0x00000001) != 0)) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 1, transactionId_);
+    }
     if (customerId_ != 0) {
-      output.writeInt32(1, customerId_);
+      output.writeInt32(2, customerId_);
     }
     getUnknownFields().writeTo(output);
   }
@@ -75,9 +127,12 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
+    if (((bitField0_ & 0x00000001) != 0)) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, transactionId_);
+    }
     if (customerId_ != 0) {
       size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(1, customerId_);
+        .computeInt32Size(2, customerId_);
     }
     size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
@@ -94,6 +149,11 @@ private static final long serialVersionUID = 0L;
     }
     sample.rpc.GetCustomerInfoRequest other = (sample.rpc.GetCustomerInfoRequest) obj;
 
+    if (hasTransactionId() != other.hasTransactionId()) return false;
+    if (hasTransactionId()) {
+      if (!getTransactionId()
+          .equals(other.getTransactionId())) return false;
+    }
     if (getCustomerId()
         != other.getCustomerId()) return false;
     if (!getUnknownFields().equals(other.getUnknownFields())) return false;
@@ -107,6 +167,10 @@ private static final long serialVersionUID = 0L;
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
+    if (hasTransactionId()) {
+      hash = (37 * hash) + TRANSACTION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getTransactionId().hashCode();
+    }
     hash = (37 * hash) + CUSTOMER_ID_FIELD_NUMBER;
     hash = (53 * hash) + getCustomerId();
     hash = (29 * hash) + getUnknownFields().hashCode();
@@ -240,6 +304,7 @@ private static final long serialVersionUID = 0L;
     public Builder clear() {
       super.clear();
       bitField0_ = 0;
+      transactionId_ = "";
       customerId_ = 0;
       return this;
     }
@@ -274,9 +339,15 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(sample.rpc.GetCustomerInfoRequest result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
+        result.transactionId_ = transactionId_;
+        to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000002) != 0)) {
         result.customerId_ = customerId_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -291,6 +362,11 @@ private static final long serialVersionUID = 0L;
 
     public Builder mergeFrom(sample.rpc.GetCustomerInfoRequest other) {
       if (other == sample.rpc.GetCustomerInfoRequest.getDefaultInstance()) return this;
+      if (other.hasTransactionId()) {
+        transactionId_ = other.transactionId_;
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       if (other.getCustomerId() != 0) {
         setCustomerId(other.getCustomerId());
       }
@@ -320,11 +396,16 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 8: {
-              customerId_ = input.readInt32();
+            case 10: {
+              transactionId_ = input.readStringRequireUtf8();
               bitField0_ |= 0x00000001;
               break;
-            } // case 8
+            } // case 10
+            case 16: {
+              customerId_ = input.readInt32();
+              bitField0_ |= 0x00000002;
+              break;
+            } // case 16
             default: {
               if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                 done = true; // was an endgroup tag
@@ -342,9 +423,88 @@ private static final long serialVersionUID = 0L;
     }
     private int bitField0_;
 
+    private java.lang.Object transactionId_ = "";
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return Whether the transactionId field is set.
+     */
+    public boolean hasTransactionId() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The transactionId.
+     */
+    public java.lang.String getTransactionId() {
+      java.lang.Object ref = transactionId_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        transactionId_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return The bytes for transactionId.
+     */
+    public com.google.protobuf.ByteString
+        getTransactionIdBytes() {
+      java.lang.Object ref = transactionId_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        transactionId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @param value The transactionId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTransactionId(
+        java.lang.String value) {
+      if (value == null) { throw new NullPointerException(); }
+      transactionId_ = value;
+      bitField0_ |= 0x00000001;
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearTransactionId() {
+      transactionId_ = getDefaultInstance().getTransactionId();
+      bitField0_ = (bitField0_ & ~0x00000001);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>optional string transaction_id = 1;</code>
+     * @param value The bytes for transactionId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setTransactionIdBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) { throw new NullPointerException(); }
+      checkByteStringIsUtf8(value);
+      transactionId_ = value;
+      bitField0_ |= 0x00000001;
+      onChanged();
+      return this;
+    }
+
     private int customerId_ ;
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @return The customerId.
      */
     @java.lang.Override
@@ -352,23 +512,23 @@ private static final long serialVersionUID = 0L;
       return customerId_;
     }
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @param value The customerId to set.
      * @return This builder for chaining.
      */
     public Builder setCustomerId(int value) {
 
       customerId_ = value;
-      bitField0_ |= 0x00000001;
+      bitField0_ |= 0x00000002;
       onChanged();
       return this;
     }
     /**
-     * <code>int32 customer_id = 1;</code>
+     * <code>int32 customer_id = 2;</code>
      * @return This builder for chaining.
      */
     public Builder clearCustomerId() {
-      bitField0_ = (bitField0_ & ~0x00000001);
+      bitField0_ = (bitField0_ & ~0x00000002);
       customerId_ = 0;
       onChanged();
       return this;

--- a/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequestOrBuilder.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/GetCustomerInfoRequestOrBuilder.java
@@ -8,7 +8,24 @@ public interface GetCustomerInfoRequestOrBuilder extends
     com.google.protobuf.MessageOrBuilder {
 
   /**
-   * <code>int32 customer_id = 1;</code>
+   * <code>optional string transaction_id = 1;</code>
+   * @return Whether the transactionId field is set.
+   */
+  boolean hasTransactionId();
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The transactionId.
+   */
+  java.lang.String getTransactionId();
+  /**
+   * <code>optional string transaction_id = 1;</code>
+   * @return The bytes for transactionId.
+   */
+  com.google.protobuf.ByteString
+      getTransactionIdBytes();
+
+  /**
+   * <code>int32 customer_id = 2;</code>
    * @return The customerId.
    */
   int getCustomerId();

--- a/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -141,21 +141,21 @@ public final class Sample {
       "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
       "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
       "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
-      "\243\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      "\244\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
       ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
-      "tomerInfoResponse\"\000\022^\n\037GetCustomerInfoIn" +
-      "TwoPhaseCommit\022\033.rpc.GetCustomerInfoRequ" +
-      "est\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\tR" +
-      "epayment\022\025.rpc.RepaymentRequest\032\026.google" +
-      ".protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Payme" +
-      "ntRequest\032\026.google.protobuf.Empty\"\000\0228\n\007P" +
-      "repare\022\023.rpc.PrepareRequest\032\026.google.pro" +
-      "tobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validate" +
-      "Request\032\026.google.protobuf.Empty\"\000\0226\n\006Com" +
-      "mit\022\022.rpc.CommitRequest\032\026.google.protobu" +
-      "f.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackRequ" +
-      "est\032\026.google.protobuf.Empty\"\000B\026\n\nsample." +
-      "rpcB\006SampleP\001b\006proto3"
+      "tomerInfoResponse\"\000\022_\n GetCustomerInfoFo" +
+      "rTwoPhaseCommit\022\033.rpc.GetCustomerInfoReq" +
+      "uest\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\t" +
+      "Repayment\022\025.rpc.RepaymentRequest\032\026.googl" +
+      "e.protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Paym" +
+      "entRequest\032\026.google.protobuf.Empty\"\000\0228\n\007" +
+      "Prepare\022\023.rpc.PrepareRequest\032\026.google.pr" +
+      "otobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validat" +
+      "eRequest\032\026.google.protobuf.Empty\"\000\0226\n\006Co" +
+      "mmit\022\022.rpc.CommitRequest\032\026.google.protob" +
+      "uf.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackReq" +
+      "uest\032\026.google.protobuf.Empty\"\000B\026\n\nsample" +
+      ".rpcB\006SampleP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -123,35 +123,39 @@ public final class Sample {
       "\001(\t\"-\n\020GetOrderResponse\022\031\n\005order\030\001 \001(\0132\n" +
       ".rpc.Order\"\'\n\020GetOrdersRequest\022\023\n\013custom" +
       "er_id\030\001 \001(\005\".\n\021GetOrdersResponse\022\031\n\005orde" +
-      "r\030\001 \003(\0132\n.rpc.Order\"-\n\026GetCustomerInfoRe" +
-      "quest\022\023\n\013customer_id\030\001 \001(\005\"_\n\027GetCustome" +
-      "rInfoResponse\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030\002 \001(\t\022" +
-      "\024\n\014credit_limit\030\003 \001(\005\022\024\n\014credit_total\030\004 " +
-      "\001(\005\"M\n\016PaymentRequest\022\026\n\016transaction_id\030" +
-      "\001 \001(\t\022\023\n\013customer_id\030\002 \001(\005\022\016\n\006amount\030\003 \001" +
-      "(\005\"7\n\020RepaymentRequest\022\023\n\013customer_id\030\001 " +
-      "\001(\005\022\016\n\006amount\030\002 \001(\005\"(\n\016PrepareRequest\022\026\n" +
-      "\016transaction_id\030\001 \001(\t\")\n\017ValidateRequest" +
-      "\022\026\n\016transaction_id\030\001 \001(\t\"\'\n\rCommitReques" +
-      "t\022\026\n\016transaction_id\030\001 \001(\t\")\n\017RollbackReq" +
-      "uest\022\026\n\016transaction_id\030\001 \001(\t2\310\001\n\014OrderSe" +
-      "rvice\022?\n\nPlaceOrder\022\026.rpc.PlaceOrderRequ" +
-      "est\032\027.rpc.PlaceOrderResponse\"\000\0229\n\010GetOrd" +
-      "er\022\024.rpc.GetOrderRequest\032\025.rpc.GetOrderR" +
-      "esponse\"\000\022<\n\tGetOrders\022\025.rpc.GetOrdersRe" +
-      "quest\032\026.rpc.GetOrdersResponse\"\0002\303\003\n\017Cust" +
-      "omerService\022N\n\017GetCustomerInfo\022\033.rpc.Get" +
-      "CustomerInfoRequest\032\034.rpc.GetCustomerInf" +
-      "oResponse\"\000\022<\n\tRepayment\022\025.rpc.Repayment" +
-      "Request\032\026.google.protobuf.Empty\"\000\0228\n\007Pay" +
-      "ment\022\023.rpc.PaymentRequest\032\026.google.proto" +
-      "buf.Empty\"\000\0228\n\007Prepare\022\023.rpc.PrepareRequ" +
-      "est\032\026.google.protobuf.Empty\"\000\022:\n\010Validat" +
-      "e\022\024.rpc.ValidateRequest\032\026.google.protobu" +
-      "f.Empty\"\000\0226\n\006Commit\022\022.rpc.CommitRequest\032" +
-      "\026.google.protobuf.Empty\"\000\022:\n\010Rollback\022\024." +
-      "rpc.RollbackRequest\032\026.google.protobuf.Em" +
-      "pty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006proto3"
+      "r\030\001 \003(\0132\n.rpc.Order\"]\n\026GetCustomerInfoRe" +
+      "quest\022\033\n\016transaction_id\030\001 \001(\tH\000\210\001\001\022\023\n\013cu" +
+      "stomer_id\030\002 \001(\005B\021\n\017_transaction_id\"_\n\027Ge" +
+      "tCustomerInfoResponse\022\n\n\002id\030\001 \001(\005\022\014\n\004nam" +
+      "e\030\002 \001(\t\022\024\n\014credit_limit\030\003 \001(\005\022\024\n\014credit_" +
+      "total\030\004 \001(\005\"M\n\016PaymentRequest\022\026\n\016transac" +
+      "tion_id\030\001 \001(\t\022\023\n\013customer_id\030\002 \001(\005\022\016\n\006am" +
+      "ount\030\003 \001(\005\"7\n\020RepaymentRequest\022\023\n\013custom" +
+      "er_id\030\001 \001(\005\022\016\n\006amount\030\002 \001(\005\"(\n\016PrepareRe" +
+      "quest\022\026\n\016transaction_id\030\001 \001(\t\")\n\017Validat" +
+      "eRequest\022\026\n\016transaction_id\030\001 \001(\t\"\'\n\rComm" +
+      "itRequest\022\026\n\016transaction_id\030\001 \001(\t\")\n\017Rol" +
+      "lbackRequest\022\026\n\016transaction_id\030\001 \001(\t2\310\001\n" +
+      "\014OrderService\022?\n\nPlaceOrder\022\026.rpc.PlaceO" +
+      "rderRequest\032\027.rpc.PlaceOrderResponse\"\000\0229" +
+      "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
+      "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
+      "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
+      "\243\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
+      "tomerInfoResponse\"\000\022^\n\037GetCustomerInfoIn" +
+      "TwoPhaseCommit\022\033.rpc.GetCustomerInfoRequ" +
+      "est\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\tR" +
+      "epayment\022\025.rpc.RepaymentRequest\032\026.google" +
+      ".protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Payme" +
+      "ntRequest\032\026.google.protobuf.Empty\"\000\0228\n\007P" +
+      "repare\022\023.rpc.PrepareRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validate" +
+      "Request\032\026.google.protobuf.Empty\"\000\0226\n\006Com" +
+      "mit\022\022.rpc.CommitRequest\032\026.google.protobu" +
+      "f.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackRequ" +
+      "est\032\026.google.protobuf.Empty\"\000B\026\n\nsample." +
+      "rpcB\006SampleP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -217,7 +221,7 @@ public final class Sample {
     internal_static_rpc_GetCustomerInfoRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_rpc_GetCustomerInfoRequest_descriptor,
-        new java.lang.String[] { "CustomerId", });
+        new java.lang.String[] { "TransactionId", "CustomerId", "TransactionId", });
     internal_static_rpc_GetCustomerInfoResponse_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_rpc_GetCustomerInfoResponse_fieldAccessorTable = new

--- a/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/java/sample/rpc/Sample.java
@@ -141,21 +141,19 @@ public final class Sample {
       "\n\010GetOrder\022\024.rpc.GetOrderRequest\032\025.rpc.G" +
       "etOrderResponse\"\000\022<\n\tGetOrders\022\025.rpc.Get" +
       "OrdersRequest\032\026.rpc.GetOrdersResponse\"\0002" +
-      "\244\004\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
+      "\303\003\n\017CustomerService\022N\n\017GetCustomerInfo\022\033" +
       ".rpc.GetCustomerInfoRequest\032\034.rpc.GetCus" +
-      "tomerInfoResponse\"\000\022_\n GetCustomerInfoFo" +
-      "rTwoPhaseCommit\022\033.rpc.GetCustomerInfoReq" +
-      "uest\032\034.rpc.GetCustomerInfoResponse\"\000\022<\n\t" +
-      "Repayment\022\025.rpc.RepaymentRequest\032\026.googl" +
-      "e.protobuf.Empty\"\000\0228\n\007Payment\022\023.rpc.Paym" +
-      "entRequest\032\026.google.protobuf.Empty\"\000\0228\n\007" +
-      "Prepare\022\023.rpc.PrepareRequest\032\026.google.pr" +
-      "otobuf.Empty\"\000\022:\n\010Validate\022\024.rpc.Validat" +
-      "eRequest\032\026.google.protobuf.Empty\"\000\0226\n\006Co" +
-      "mmit\022\022.rpc.CommitRequest\032\026.google.protob" +
-      "uf.Empty\"\000\022:\n\010Rollback\022\024.rpc.RollbackReq" +
-      "uest\032\026.google.protobuf.Empty\"\000B\026\n\nsample" +
-      ".rpcB\006SampleP\001b\006proto3"
+      "tomerInfoResponse\"\000\022<\n\tRepayment\022\025.rpc.R" +
+      "epaymentRequest\032\026.google.protobuf.Empty\"" +
+      "\000\0228\n\007Payment\022\023.rpc.PaymentRequest\032\026.goog" +
+      "le.protobuf.Empty\"\000\0228\n\007Prepare\022\023.rpc.Pre" +
+      "pareRequest\032\026.google.protobuf.Empty\"\000\022:\n" +
+      "\010Validate\022\024.rpc.ValidateRequest\032\026.google" +
+      ".protobuf.Empty\"\000\0226\n\006Commit\022\022.rpc.Commit" +
+      "Request\032\026.google.protobuf.Empty\"\000\022:\n\010Rol" +
+      "lback\022\024.rpc.RollbackRequest\032\026.google.pro" +
+      "tobuf.Empty\"\000B\026\n\nsample.rpcB\006SampleP\001b\006p" +
+      "roto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,9 +73,6 @@ service CustomerService {
   // Get customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
-  // Get customer information
-  rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
-  }
   // Credit card repayment
   rpc Repayment(RepaymentRequest) returns (google.protobuf.Empty) {
   }

--- a/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -70,7 +70,7 @@ message GetOrdersResponse {
 
 // for Customer Service
 service CustomerService {
-  // Get a customer information
+  // Get customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Get customer information

--- a/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -74,7 +74,7 @@ service CustomerService {
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Get a customer information
-  rpc GetCustomerInfoInTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
+  rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Credit card repayment
   rpc Repayment(RepaymentRequest) returns (google.protobuf.Empty) {

--- a/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,7 +73,7 @@ service CustomerService {
   // Get a customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
-  // Get a customer information
+  // Get customer information
   rpc GetCustomerInfoForTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
   // Credit card repayment

--- a/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
+++ b/spring-data-microservice-transaction-sample/rpc/src/main/proto/sample.proto
@@ -73,6 +73,9 @@ service CustomerService {
   // Get a customer information
   rpc GetCustomerInfo(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
   }
+  // Get a customer information
+  rpc GetCustomerInfoInTwoPhaseCommit(GetCustomerInfoRequest) returns (GetCustomerInfoResponse) {
+  }
   // Credit card repayment
   rpc Repayment(RepaymentRequest) returns (google.protobuf.Empty) {
   }
@@ -97,7 +100,8 @@ service CustomerService {
 }
 
 message GetCustomerInfoRequest {
-  int32 customer_id = 1;
+  optional string transaction_id = 1;
+  int32 customer_id = 2;
 }
 
 message GetCustomerInfoResponse {


### PR DESCRIPTION
## Description

The current micro-service samples call `CustomerService.getCustomerInfo` endpoint from `OrderService.getOrder(s)` endpoints as a separate transaction without using 2PC interface. As a result, 2 or more transactions are created when invoking `CustomerService.getCustomerInfo` endpoint.

This behavior may be good in terms of performance. But there are the following concerns:
1. Strictly speaking, the operations of `CustomerService.getCustomerInfo` is supposed to be a part of the global transaction starting with `OrderService.getOrder(s)`. So, creating 2 or more transaction ID in the coordinator table might be unexpected.
2. If users who develop their application based on this sample adds write operation in `CustomerService.getCustomerInfo` or `OrderService.getOrder(s)`, it might cause anomalies which is difficult to detect.

So, it's reasonable to call `CustomerService.getCustomerInfo` endpoint from `OrderService.getOrder(s)`  in a 2PC transaction.

## Related issues and/or PRs

N/A

## Changes made

This PR does:
- ~~Add a new endpoint `CustomerService.getCustomerInfoForTwoPhaseCommit` which joins a global transaction created by other service (OrderService)~~
- ~~Make `OrderService.getOrder(s)` call the new endpoint `CustomerService.getCustomerInfoForTwoPhaseCommit` instead of `CustomerService.getCustomerInfo` which starts with a new transaction~~
- Make `CustomerService.getCustomerInfo` work as a participant service endpoint when receiving a transaction ID
- Make `OrderService.getOrder(s)` to pass the transaction ID to `CustomerService.getCustomerInfo` endpoint
- Update the documents

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- ~~Probably `getCustomerInfoForTwoPhaseCommit` be not the best name. Any feedback is welcome!~~
  - Removed the endpoint
- [This change](https://github.com/scalar-labs/scalardb-samples/compare/microservice-use-same-txid-in-getorder?expand=1#diff-69ff4689ac578f67b7bc402d05a46536351117c7f9f3b139f71daee01f3bf7e1R192) is to avoid calling `CustomerService.getCustomerInfo` multiple times. That's because the 2nd call of  `getCustomerInfo` in a global transaction fails since it always joins a specific transaction for now not resumes it. It would make things complicated if we make the method properly call either of `join(tx_id)` or `resume(tx_id)`. This is a kind of reusability issue. I've already discussed it with @brfrn169 and we may address the issue by making `join(tx_id)` allow to resume a transaction in the future

