### PR TITLE
Add databases to ScalarDB Sample

### DIFF
--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -10,7 +10,19 @@
 # scalar.db.username=postgres
 # scalar.db.password=postgres
 
-# For DynamoDB
+# For Oracle
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:oracle:thin:@//localhost:1521/FREEPDB1
+# scalar.db.username=SYSTEM
+# scalar.db.password=Oracle
+
+# For SQL Server
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:sqlserver://localhost:1433;encrypt=true;trustServerCertificate=true
+# scalar.db.username=sa
+# scalar.db.password=SqlServer22
+
+# For DynamoDB Local
 # scalar.db.storage=dynamo
 # scalar.db.contact_points=sample
 # scalar.db.username=sample

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -1,25 +1,41 @@
 version: "3.5"
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.1
+    container_name: "mysql-1"
     environment:
       MYSQL_ROOT_PASSWORD: mysql
-    container_name: "mysql-1"
     ports:
       - "3306:3306"
   postgres:
-    image: postgres:12-alpine
+    image: postgres:15
     container_name: "postgres-1"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - 5432:5432
+      - "5432:5432"
+  oracle:
+    image: container-registry.oracle.com/database/free:23.4.0.0
+    container_name: "oracle-1"
+    environment:
+      ORACLE_PWD: Oracle
+    ports:
+      - "1521:1521"
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: "sqlserver-1"
+    environment:
+      MSSQL_PID: "Express"
+      SA_PASSWORD: "SqlServer22"
+      ACCEPT_EULA: "Y"
+    ports:
+      - "1433:1433"
   dynamodb:
-    image: amazon/dynamodb-local:1.17.0
+    image: amazon/dynamodb-local:2.5.2
     container_name: "dynamodb-1"
     ports:
-      - 8000:8000
+      - "8000:8000"
   cassandra:
     image: cassandra:3.11
     container_name: "cassandra-1"


### PR DESCRIPTION
## Description

This PR adds some databases to ScalarDB Sample.

## Related issues and/or PRs

N/A

## Changes made

- Added Oracle Database and SQL Server to `database.properties` and `docker-compose.yml` in ScalarDB Sample.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
