### PR TITLE
Remove version element in Docker Compose files

### DIFF
--- a/microservice-transaction-sample/docker-compose.yml
+++ b/microservice-transaction-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.0

--- a/multi-storage-transaction-sample/docker-compose.yml
+++ b/multi-storage-transaction-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.0

--- a/scalardb-analytics-postgresql-sample/docker-compose.yml
+++ b/scalardb-analytics-postgresql-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   analytics:
     image: ghcr.io/scalar-labs/scalardb-analytics-postgresql:3.10.3

--- a/scalardb-analytics-spark-sample/docker-compose.yml
+++ b/scalardb-analytics-spark-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   spark-shell:
     build:

--- a/scalardb-cluster-standalone-mode/docker-compose.yaml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.1

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.1

--- a/spring-data-microservice-transaction-sample/docker-compose.yml
+++ b/spring-data-microservice-transaction-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.0

--- a/spring-data-multi-storage-transaction-sample/docker-compose.yml
+++ b/spring-data-multi-storage-transaction-sample/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.5"
 services:
   mysql:
     image: mysql:8.0


### PR DESCRIPTION
## Description

This PR removes the version element in Docker Compose files since it's obsolete. This was discussed in the comment https://github.com/scalar-labs/scalardb-samples/pull/65#discussion_r1690610604.

## Related issues and/or PRs

N/A

## Changes made

- Removed the version element in Docker Compose files.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
