### PR TITLE
Enable GraphQL and SQL in ScalarDB Cluster standalone mode

### DIFF
--- a/scalardb-cluster-standalone-mode/docker-compose.yaml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
     container_name: "scalardb-cluser-node"
     ports:
       - "60053:60053"
+      - "8080:8080"
       - "9080:9080"
     volumes:
       - ./scalardb-cluster-node.properties:/scalardb-cluster/node/scalardb-cluster-node.properties

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -43,6 +43,12 @@
 # Standalone mode
 scalar.db.cluster.node.standalone_mode.enabled=true
 
+# GraphQL
+scalar.db.graphql.enabled=true
+
+# SQL
+scalar.db.sql.enabled=true
+
 # License key configurations
 scalar.db.cluster.node.licensing.license_key=
 scalar.db.cluster.node.licensing.license_check_cert_pem=


### PR DESCRIPTION
## Description

This PR enables GraphQL and SQL in the docker compose file of the ScalarDB Cluster standalone mode.

## Related issues and/or PRs

N/A

## Changes made


## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
