### PR TITLE
Fix settings to build with newer Java version

### DIFF
--- a/spring-data-microservice-transaction-sample/rpc/build.gradle
+++ b/spring-data-microservice-transaction-sample/rpc/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api "io.grpc:grpc-protobuf:${grpcVersion}"
     api "io.grpc:grpc-stub:${grpcVersion}"
     api "io.grpc:grpc-services:${grpcVersion}"
+    api "javax.annotation:javax.annotation-api:1.3.2"
 }
 
 protobuf {

--- a/spring-data-multi-storage-transaction-sample/build.gradle
+++ b/spring-data-multi-storage-transaction-sample/build.gradle
@@ -23,15 +23,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
 }
 
-spotless {
-    java {
-        target 'src/*/java/**/*.java'
-        importOrder()
-        removeUnusedImports()
-        googleJavaFormat()
-    }
-}
-
 application {
     mainClassName = 'sample.SampleApp'
 }

--- a/spring-data-sample/build.gradle
+++ b/spring-data-sample/build.gradle
@@ -23,15 +23,6 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
 }
 
-spotless {
-    java {
-        target 'src/*/java/**/*.java'
-        importOrder()
-        removeUnusedImports()
-        googleJavaFormat()
-    }
-}
-
 application {
     mainClassName = 'sample.SampleApp'
 }


### PR DESCRIPTION
## Description

This PR modifies some build.gradle files to build all ScalarDB samples with Java 8, 11, 17.

## Related issues and/or PRs

N/A

## Changes made

- I remove spotlessJava task because an error occurs at the removeUnusedImports() in spotlessJava task (This error is reported by [an issue](https://github.com/google/google-java-format/issues/1079) in google-java-format) and the task is only used in two samples. This decision was approved by @brfrn169.
- I add java.annotation dependency explicitly because javax.annotation.Generated used in one sample is not included in Java 9 and later (ref. https://github.com/grpc/grpc-java/issues/9179).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.
