### PR TITLE
Replace deprecated Gradle/ScalarDB features

### DIFF
--- a/microservice-transaction-sample/client/build.gradle
+++ b/microservice-transaction-sample/client/build.gradle
@@ -10,10 +10,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.client.Client'
+    mainClass = 'sample.client.Client'
 }
 
-archivesBaseName = "sample-order-service"
+base {
+    archivesName = "sample-order-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/microservice-transaction-sample/customer-service/build.gradle
+++ b/microservice-transaction-sample/customer-service/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.customer.CustomerServiceServer'
+    mainClass = 'sample.customer.CustomerServiceServer'
 }
 
 task copyFilesToDockerBuildContextDir(type: Copy) {
@@ -47,7 +47,12 @@ installDist {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
 }
 
-archivesBaseName = "sample-customer-service"
+base {
+    archivesName = "sample-customer-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/CustomerService.java
@@ -74,7 +74,7 @@ public class CustomerService extends CustomerServiceGrpc.CustomerServiceImplBase
       throws CrudException {
     Optional<Customer> customer = Customer.get(transaction, id);
     if (!customer.isPresent()) {
-      Customer.put(transaction, id, name, creditLimit, creditTotal);
+      Customer.insert(transaction, id, name, creditLimit, creditTotal);
     }
   }
 

--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/model/Customer.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/model/Customer.java
@@ -28,7 +28,7 @@ public class Customer {
     this.creditTotal = creditTotal;
   }
 
-  public static void put(
+  public static void insert(
       TransactionCrudOperable transaction, int id, String name, int creditLimit, int creditTotal)
       throws CrudException {
     transaction.insert(

--- a/microservice-transaction-sample/customer-service/src/main/java/sample/customer/model/Customer.java
+++ b/microservice-transaction-sample/customer-service/src/main/java/sample/customer/model/Customer.java
@@ -1,8 +1,9 @@
 package sample.customer.model;
 
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.TransactionCrudOperable;
+import com.scalar.db.api.Update;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.io.Key;
 import java.util.Optional;
@@ -30,8 +31,8 @@ public class Customer {
   public static void put(
       TransactionCrudOperable transaction, int id, String name, int creditLimit, int creditTotal)
       throws CrudException {
-    transaction.put(
-        Put.newBuilder()
+    transaction.insert(
+        Insert.newBuilder()
             .namespace(NAMESPACE)
             .table(TABLE)
             .partitionKey(Key.ofInt(COL_CUSTOMER_ID, id))
@@ -43,8 +44,8 @@ public class Customer {
 
   public static void updateCreditTotal(TransactionCrudOperable transaction, int id, int creditTotal)
       throws CrudException {
-    transaction.put(
-        Put.newBuilder()
+    transaction.update(
+        Update.newBuilder()
             .namespace(NAMESPACE)
             .table(TABLE)
             .partitionKey(Key.ofInt(COL_CUSTOMER_ID, id))

--- a/microservice-transaction-sample/order-service/build.gradle
+++ b/microservice-transaction-sample/order-service/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.order.OrderServiceServer'
+    mainClass = 'sample.order.OrderServiceServer'
 }
 
 task copyFilesToDockerBuildContextDir(type: Copy) {
@@ -47,7 +47,12 @@ installDist {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
 }
 
-archivesBaseName = "sample-order-service"
+base {
+    archivesName = "sample-order-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/OrderService.java
@@ -94,7 +94,7 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
       DistributedTransaction transaction, int id, String name, int price) throws CrudException {
     Optional<Item> item = Item.get(transaction, id);
     if (!item.isPresent()) {
-      Item.put(transaction, id, name, price);
+      Item.insert(transaction, id, name, price);
     }
   }
 
@@ -106,13 +106,13 @@ public class OrderService extends OrderServiceGrpc.OrderServiceImplBase implemen
         transaction -> {
           String orderId = UUID.randomUUID().toString();
 
-          // Put the order info into the orders table
-          Order.put(transaction, orderId, request.getCustomerId(), System.currentTimeMillis());
+          // Insert the order info into the orders table
+          Order.insert(transaction, orderId, request.getCustomerId(), System.currentTimeMillis());
 
           int amount = 0;
           for (ItemOrder itemOrder : request.getItemOrderList()) {
-            // Put the order statement into the statements table
-            Statement.put(transaction, orderId, itemOrder.getItemId(), itemOrder.getCount());
+            // Insert the order statement into the statements table
+            Statement.insert(transaction, orderId, itemOrder.getItemId(), itemOrder.getCount());
 
             // Retrieve the item info from the items table
             Optional<Item> item = Item.get(transaction, itemOrder.getItemId());

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Item.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Item.java
@@ -25,7 +25,7 @@ public class Item {
     this.price = price;
   }
 
-  public static void put(TransactionCrudOperable transaction, int id, String name, int price)
+  public static void insert(TransactionCrudOperable transaction, int id, String name, int price)
       throws CrudException {
     transaction.insert(
         Insert.newBuilder()

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Item.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Item.java
@@ -1,7 +1,7 @@
 package sample.order.model;
 
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.exception.transaction.CrudException;
 import com.scalar.db.io.Key;
@@ -27,8 +27,8 @@ public class Item {
 
   public static void put(TransactionCrudOperable transaction, int id, String name, int price)
       throws CrudException {
-    transaction.put(
-        Put.newBuilder()
+    transaction.insert(
+        Insert.newBuilder()
             .namespace(NAMESPACE)
             .table(TABLE)
             .partitionKey(Key.ofInt(COL_ITEM_ID, id))

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Order.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Order.java
@@ -1,7 +1,7 @@
 package sample.order.model;
 
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.Scan.Ordering;
@@ -33,8 +33,8 @@ public class Order {
   public static void put(
       TransactionCrudOperable transaction, String id, int customerId, long timestamp)
       throws CrudException {
-    transaction.put(
-        Put.newBuilder()
+    transaction.insert(
+        Insert.newBuilder()
             .namespace(NAMESPACE)
             .table(TABLE)
             .partitionKey(Key.ofInt(COL_CUSTOMER_ID, customerId))

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Order.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Order.java
@@ -30,7 +30,7 @@ public class Order {
     this.timestamp = timestamp;
   }
 
-  public static void put(
+  public static void insert(
       TransactionCrudOperable transaction, String id, int customerId, long timestamp)
       throws CrudException {
     transaction.insert(

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Statement.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Statement.java
@@ -1,6 +1,6 @@
 package sample.order.model;
 
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Scan;
 import com.scalar.db.api.TransactionCrudOperable;
 import com.scalar.db.exception.transaction.CrudException;
@@ -28,8 +28,8 @@ public class Statement {
 
   public static void put(TransactionCrudOperable transaction, String orderId, int itemId, int count)
       throws CrudException {
-    transaction.put(
-        Put.newBuilder()
+    transaction.insert(
+        Insert.newBuilder()
             .namespace(NAMESPACE)
             .table(TABLE)
             .partitionKey(Key.ofText(COL_ORDER_ID, orderId))

--- a/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Statement.java
+++ b/microservice-transaction-sample/order-service/src/main/java/sample/order/model/Statement.java
@@ -26,7 +26,7 @@ public class Statement {
     this.count = count;
   }
 
-  public static void put(TransactionCrudOperable transaction, String orderId, int itemId, int count)
+  public static void insert(TransactionCrudOperable transaction, String orderId, int itemId, int count)
       throws CrudException {
     transaction.insert(
         Insert.newBuilder()

--- a/microservice-transaction-sample/rpc/build.gradle
+++ b/microservice-transaction-sample/rpc/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'java-library-distribution'
-    id 'com.google.protobuf' version '0.9.1'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 dependencies {
@@ -20,10 +20,26 @@ protobuf {
     generateProtoTasks {
         all()*.plugins { grpc {} }
     }
-    generatedFilesBaseDir = "$projectDir/src"
 }
 
-archivesBaseName = "sample-rpc"
+base {
+    archivesName = "sample-rpc"
+}
+
+// Task copyGeneratedProtoToSrc copies the generated .java files into src directory
+task copyGeneratedProtoToSrc(type: Copy) {
+    description 'Copies generated Protocol Buffer classes to src/main/java/sample/rpc'
+    dependsOn generateProto
+    from "$buildDir/generated/source/proto/main/java/sample/rpc"
+    into "$projectDir/src/main/java/sample/rpc"
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+// Task deleteBuildMainJava deletes the generated .java files in build directory
+task deleteBuildMainJava(type: Delete) {
+    dependsOn copyGeneratedProtoToSrc
+    delete fileTree(dir: "$buildDir/generated/source/proto/main/java/sample/rpc")
+}
 
 // The processResources task needs to depend on the generateProto task because it uses the output
 // of the the generateProto task
@@ -31,5 +47,13 @@ processResources {
     dependsOn generateProto
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+// Task deleteBuildMainJava needs to depend on deleteBuildMainJava to avoid duplicate class error
+tasks.named("compileJava").configure {
+    dependsOn deleteBuildMainJava
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/microservice-transaction-sample/rpc/build.gradle
+++ b/microservice-transaction-sample/rpc/build.gradle
@@ -35,8 +35,8 @@ task copyGeneratedProtoToSrc(type: Copy) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-// Task deleteBuildMainJava deletes the generated .java files in build directory
-task deleteBuildMainJava(type: Delete) {
+// Task deleteGeneratedProto deletes the generated .java files in build directory
+task deleteGeneratedProto(type: Delete) {
     dependsOn copyGeneratedProtoToSrc
     delete fileTree(dir: "$buildDir/generated/source/proto/main/java/sample/rpc")
 }
@@ -47,9 +47,9 @@ processResources {
     dependsOn generateProto
 }
 
-// Task deleteBuildMainJava needs to depend on deleteBuildMainJava to avoid duplicate class error
+// Task deleteGeneratedProto needs to depend on deleteGeneratedProto to avoid duplicate class error
 tasks.named("compileJava").configure {
-    dependsOn deleteBuildMainJava
+    dependsOn deleteGeneratedProto
 }
 
 java {

--- a/multi-storage-transaction-sample/build.gradle
+++ b/multi-storage-transaction-sample/build.gradle
@@ -16,10 +16,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.command.SampleCommand'
+    mainClass = 'sample.command.SampleCommand'
 }
 
-archivesBaseName = "sample"
+base {
+    archivesName = "sample"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/multi-storage-transaction-sample/src/main/java/sample/Sample.java
+++ b/multi-storage-transaction-sample/src/main/java/sample/Sample.java
@@ -3,9 +3,10 @@ package sample;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.TransactionFactory;
@@ -62,8 +63,8 @@ public class Sample implements AutoCloseable {
                 .partitionKey(Key.ofInt("customer_id", customerId))
                 .build());
     if (!customer.isPresent()) {
-      transaction.put(
-          Put.newBuilder()
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("customer")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -85,8 +86,8 @@ public class Sample implements AutoCloseable {
                 .partitionKey(Key.ofInt("item_id", itemId))
                 .build());
     if (!item.isPresent()) {
-      transaction.put(
-          Put.newBuilder()
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("order")
               .table("items")
               .partitionKey(Key.ofInt("item_id", itemId))
@@ -146,9 +147,9 @@ public class Sample implements AutoCloseable {
       // Start a transaction
       transaction = manager.start();
 
-      // Put the order info into the orders table
-      transaction.put(
-          Put.newBuilder()
+      // Insert the order info into the orders table
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("order")
               .table("orders")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -161,9 +162,9 @@ public class Sample implements AutoCloseable {
         int itemId = itemIds[i];
         int count = itemCounts[i];
 
-        // Put the order statement into the statements table
-        transaction.put(
-            Put.newBuilder()
+        // Insert the order statement into the statements table
+        transaction.insert(
+            Insert.newBuilder()
                 .namespace("order")
                 .table("statements")
                 .partitionKey(Key.ofText("order_id", orderId))
@@ -206,8 +207,8 @@ public class Sample implements AutoCloseable {
       }
 
       // Update credit_total for the customer
-      transaction.put(
-          Put.newBuilder()
+      transaction.update(
+          Update.newBuilder()
               .namespace("customer")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -389,8 +390,8 @@ public class Sample implements AutoCloseable {
       }
 
       // Reduce credit_total for the customer
-      transaction.put(
-          Put.newBuilder()
+      transaction.update(
+          Update.newBuilder()
               .namespace("customer")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))

--- a/scalardb-kotlin-sample/build.gradle.kts
+++ b/scalardb-kotlin-sample/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm") version "2.0.21"
     application
 }
 
@@ -21,13 +21,8 @@ tasks.test {
     useJUnitPlatform()
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+kotlin {
+    jvmToolchain(8)
 }
 
 application {

--- a/scalardb-kotlin-sample/src/main/kotlin/sample/ElectronicMoney.kt
+++ b/scalardb-kotlin-sample/src/main/kotlin/sample/ElectronicMoney.kt
@@ -2,7 +2,8 @@ package sample
 
 import com.scalar.db.api.DistributedTransactionManager
 import com.scalar.db.api.Get
-import com.scalar.db.api.Put
+import com.scalar.db.api.Update
+import com.scalar.db.api.Upsert
 import com.scalar.db.exception.transaction.TransactionException
 import com.scalar.db.io.Key
 import com.scalar.db.service.TransactionFactory
@@ -43,13 +44,13 @@ class ElectronicMoney(scalarDBProperties: String) {
             }
 
             // Update the balance
-            val put = Put.newBuilder()
+            val upsert = Upsert.newBuilder()
                 .namespace(NAMESPACE)
                 .table(TABLENAME)
                 .partitionKey(Key.ofText(ID, id))
                 .intValue(BALANCE, balance)
                 .build()
-            tx.put(put)
+            tx.upsert(upsert)
 
             // Commit the transaction (records are automatically recovered in case of failure)
             tx.commit()
@@ -86,20 +87,20 @@ class ElectronicMoney(scalarDBProperties: String) {
             }
 
             // Update the balances
-            val fromPut = Put.newBuilder()
+            val fromUpdate = Update.newBuilder()
                 .namespace(NAMESPACE)
                 .table(TABLENAME)
                 .partitionKey(Key.ofText(ID, fromId))
                 .intValue(BALANCE, newFromBalance)
                 .build()
-            val toPut = Put.newBuilder()
+            val toUpdate = Update.newBuilder()
                 .namespace(NAMESPACE)
                 .table(TABLENAME)
                 .partitionKey(Key.ofText(ID, toId))
                 .intValue(BALANCE, newToBalance)
                 .build()
-            tx.put(fromPut)
-            tx.put(toPut)
+            tx.update(fromUpdate)
+            tx.update(toUpdate)
 
             // Commit the transaction (records are automatically recovered in case of failure)
             tx.commit()

--- a/scalardb-sample/build.gradle
+++ b/scalardb-sample/build.gradle
@@ -16,10 +16,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.command.SampleCommand'
+    mainClass = 'sample.command.SampleCommand'
 }
 
-archivesBaseName = "sample"
+base {
+    archivesName = "sample"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/scalardb-sample/src/main/java/sample/Sample.java
+++ b/scalardb-sample/src/main/java/sample/Sample.java
@@ -3,9 +3,10 @@ package sample;
 import com.scalar.db.api.DistributedTransaction;
 import com.scalar.db.api.DistributedTransactionManager;
 import com.scalar.db.api.Get;
-import com.scalar.db.api.Put;
+import com.scalar.db.api.Insert;
 import com.scalar.db.api.Result;
 import com.scalar.db.api.Scan;
+import com.scalar.db.api.Update;
 import com.scalar.db.exception.transaction.TransactionException;
 import com.scalar.db.io.Key;
 import com.scalar.db.service.TransactionFactory;
@@ -62,8 +63,8 @@ public class Sample implements AutoCloseable {
                 .partitionKey(Key.ofInt("customer_id", customerId))
                 .build());
     if (!customer.isPresent()) {
-      transaction.put(
-          Put.newBuilder()
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("sample")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -85,8 +86,8 @@ public class Sample implements AutoCloseable {
                 .partitionKey(Key.ofInt("item_id", itemId))
                 .build());
     if (!item.isPresent()) {
-      transaction.put(
-          Put.newBuilder()
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("sample")
               .table("items")
               .partitionKey(Key.ofInt("item_id", itemId))
@@ -146,9 +147,9 @@ public class Sample implements AutoCloseable {
       // Start a transaction
       transaction = manager.start();
 
-      // Put the order info into the orders table
-      transaction.put(
-          Put.newBuilder()
+      // Insert the order info into the orders table
+      transaction.insert(
+          Insert.newBuilder()
               .namespace("sample")
               .table("orders")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -161,9 +162,9 @@ public class Sample implements AutoCloseable {
         int itemId = itemIds[i];
         int count = itemCounts[i];
 
-        // Put the order statement into the statements table
-        transaction.put(
-            Put.newBuilder()
+        // Insert the order statement into the statements table
+        transaction.insert(
+            Insert.newBuilder()
                 .namespace("sample")
                 .table("statements")
                 .partitionKey(Key.ofText("order_id", orderId))
@@ -205,8 +206,8 @@ public class Sample implements AutoCloseable {
       }
 
       // Update credit_total for the customer
-      transaction.put(
-          Put.newBuilder()
+      transaction.update(
+          Update.newBuilder()
               .namespace("sample")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))
@@ -388,8 +389,8 @@ public class Sample implements AutoCloseable {
       }
 
       // Reduce credit_total for the customer
-      transaction.put(
-          Put.newBuilder()
+      transaction.update(
+          Update.newBuilder()
               .namespace("sample")
               .table("customers")
               .partitionKey(Key.ofInt("customer_id", customerId))

--- a/scalardb-sql-jdbc-sample/build.gradle
+++ b/scalardb-sql-jdbc-sample/build.gradle
@@ -17,10 +17,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.command.SampleCommand'
+    mainClass = 'sample.command.SampleCommand'
 }
 
-archivesBaseName = "sample"
+base {
+    archivesName = "sample"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-microservice-transaction-sample/client/build.gradle
+++ b/spring-data-microservice-transaction-sample/client/build.gradle
@@ -10,10 +10,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.client.Client'
+    mainClass = 'sample.client.Client'
 }
 
-archivesBaseName = "sample-order-service"
+base {
+    archivesName = "sample-order-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-microservice-transaction-sample/customer-service/build.gradle
+++ b/spring-data-microservice-transaction-sample/customer-service/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.customer.CustomerServiceServer'
+    mainClass = 'sample.customer.CustomerServiceServer'
 }
 
 task copyFilesToDockerBuildContextDir(type: Copy) {
@@ -49,7 +49,12 @@ installDist {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
 }
 
-archivesBaseName = "sample-customer-service"
+base {
+    archivesName = "sample-customer-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-microservice-transaction-sample/order-service/build.gradle
+++ b/spring-data-microservice-transaction-sample/order-service/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.order.OrderServiceServer'
+    mainClass = 'sample.order.OrderServiceServer'
 }
 
 task copyFilesToDockerBuildContextDir(type: Copy) {
@@ -49,7 +49,12 @@ installDist {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
 }
 
-archivesBaseName = "sample-order-service"
+base {
+    archivesName = "sample-order-service"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-microservice-transaction-sample/rpc/build.gradle
+++ b/spring-data-microservice-transaction-sample/rpc/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'java-library-distribution'
-    id 'com.google.protobuf' version '0.9.1'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 dependencies {
@@ -20,10 +20,26 @@ protobuf {
     generateProtoTasks {
         all()*.plugins { grpc {} }
     }
-    generatedFilesBaseDir = "$projectDir/src"
 }
 
-archivesBaseName = "sample-rpc"
+base {
+    archivesName = "sample-rpc"
+}
+
+// Task copyGeneratedProtoToSrc copies the generated .java files into src directory
+task copyGeneratedProtoToSrc(type: Copy) {
+    description 'Copies generated Protocol Buffer classes to src/main/java/sample/rpc'
+    dependsOn generateProto
+    from "$buildDir/generated/source/proto/main/java/sample/rpc"
+    into "$projectDir/src/main/java/sample/rpc"
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+// Task deleteBuildMainJava deletes the generated .java files in build directory
+task deleteBuildMainJava(type: Delete) {
+    dependsOn copyGeneratedProtoToSrc
+    delete fileTree(dir: "$buildDir/generated/source/proto/main/java/sample/rpc")
+}
 
 // The processResources task needs to depend on the generateProto task because it uses the output
 // of the the generateProto task
@@ -31,5 +47,13 @@ processResources {
     dependsOn generateProto
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+// Task deleteBuildMainJava needs to depend on deleteBuildMainJava to avoid duplicate class error
+tasks.named("compileJava").configure {
+    dependsOn deleteBuildMainJava
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-microservice-transaction-sample/rpc/build.gradle
+++ b/spring-data-microservice-transaction-sample/rpc/build.gradle
@@ -35,8 +35,8 @@ task copyGeneratedProtoToSrc(type: Copy) {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-// Task deleteBuildMainJava deletes the generated .java files in build directory
-task deleteBuildMainJava(type: Delete) {
+// Task deleteGeneratedProto deletes the generated .java files in build directory
+task deleteGeneratedProto(type: Delete) {
     dependsOn copyGeneratedProtoToSrc
     delete fileTree(dir: "$buildDir/generated/source/proto/main/java/sample/rpc")
 }
@@ -47,9 +47,9 @@ processResources {
     dependsOn generateProto
 }
 
-// Task deleteBuildMainJava needs to depend on deleteBuildMainJava to avoid duplicate class error
+// Task deleteGeneratedProto needs to depend on deleteGeneratedProto to avoid duplicate class error
 tasks.named("compileJava").configure {
-    dependsOn deleteBuildMainJava
+    dependsOn deleteGeneratedProto
 }
 
 java {

--- a/spring-data-multi-storage-transaction-sample/build.gradle
+++ b/spring-data-multi-storage-transaction-sample/build.gradle
@@ -24,10 +24,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.SampleApp'
+    mainClass = 'sample.SampleApp'
 }
 
-archivesBaseName = "sample"
+base {
+    archivesName = "sample"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}

--- a/spring-data-sample/build.gradle
+++ b/spring-data-sample/build.gradle
@@ -24,10 +24,15 @@ dependencies {
 }
 
 application {
-    mainClassName = 'sample.SampleApp'
+    mainClass = 'sample.SampleApp'
 }
 
-archivesBaseName = "sample"
+base {
+    archivesName = "sample"
+}
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}


### PR DESCRIPTION
## Description

This PR replaces deprecated Gradle/ScalarDB features to suppress warning messages.

The sample applications of ScalarDB use some deprecated Gradle features and `put` API of ScalarDB. Due to these reasons, multiple warning messages are displayed when the sample application is executed, which is annoying to users.

So this PR replaces all deprecated Gradle features and replaces `put` API of ScalarDB with `update`/`insert`.

## Related issues and/or PRs

N/A

## Changes made

- Replace deprecated Gradle features.
- Replace `put` API of ScalarDB with `update`/`insert`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
