### PR TITLE
Add Db2 Docker container setup and configuration

### DIFF
--- a/scalardb-cluster-standalone-mode/docker-compose.yaml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yaml
@@ -40,9 +40,20 @@ services:
     container_name: "cassandra-1"
     ports:
       - "9042:9042"
+  db2:
+    image: icr.io/db2_community/db2:12.1.1.0
+    container_name: "db2-1"
+    environment:
+      - DB2INSTANCE=db2inst1
+      - DB2INST1_PASSWORD=db2inst1
+      - DBNAME=sample
+      - LICENSE=accept
+    ports:
+      - "50000:50000"
+    privileged: true
 
   scalardb-cluster-node:
-    image: ghcr.io/scalar-labs/scalardb-cluster-node-byol-premium:3.13.0
+    image: ghcr.io/scalar-labs/scalardb-cluster-node-byol-premium:3.16.0
     container_name: "scalardb-cluster-node"
     ports:
       - "60053:60053"

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -40,6 +40,12 @@
 # scalar.db.username=cassandra
 # scalar.db.password=cassandra
 
+# For Db2
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:db2://localhost:50000/sample
+# scalar.db.username=db2inst1
+# scalar.db.password=db2inst1
+
 # Standalone mode
 scalar.db.cluster.node.standalone_mode.enabled=true
 

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -42,7 +42,7 @@
 
 # For Db2
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:db2://localhost:50000/sample
+# scalar.db.contact_points=jdbc:db2://db2-1:50000/sample
 # scalar.db.username=db2inst1
 # scalar.db.password=db2inst1
 

--- a/scalardb-kotlin-sample/build.gradle.kts
+++ b/scalardb-kotlin-sample/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.scalar-labs", "scalardb", "3.13.0")
+    implementation("com.scalar-labs", "scalardb", "3.16.0")
     testImplementation(kotlin("test"))
 }
 

--- a/scalardb-kotlin-sample/database.properties
+++ b/scalardb-kotlin-sample/database.properties
@@ -39,3 +39,9 @@
 # scalar.db.contact_points=localhost
 # scalar.db.username=cassandra
 # scalar.db.password=cassandra
+
+# For Db2
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:db2://localhost:50000/sample
+# scalar.db.username=db2inst1
+# scalar.db.password=db2inst1

--- a/scalardb-kotlin-sample/docker-compose.yml
+++ b/scalardb-kotlin-sample/docker-compose.yml
@@ -40,3 +40,14 @@ services:
     container_name: "cassandra-1"
     ports:
       - "9042:9042"
+  db2:
+    image: icr.io/db2_community/db2:12.1.1.0
+    container_name: "db2-1"
+    environment:
+      - DB2INSTANCE=db2inst1
+      - DB2INST1_PASSWORD=db2inst1
+      - DBNAME=sample
+      - LICENSE=accept
+    ports:
+      - "50000:50000"
+    privileged: true

--- a/scalardb-sample/build.gradle
+++ b/scalardb-sample/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.scalar-labs:scalardb:3.13.0'
+    implementation 'com.scalar-labs:scalardb:3.16.0'
     implementation 'info.picocli:picocli:4.7.1'
 }
 

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -39,3 +39,9 @@
 # scalar.db.contact_points=localhost
 # scalar.db.username=cassandra
 # scalar.db.password=cassandra
+
+# For Db2
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:db2://localhost:50000/sample
+# scalar.db.username=db2inst1
+# scalar.db.password=db2inst1

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -40,3 +40,14 @@ services:
     container_name: "cassandra-1"
     ports:
       - "9042:9042"
+  db2:
+    image: icr.io/db2_community/db2:12.1.1.0
+    container_name: "db2-1"
+    environment:
+      - DB2INSTANCE=db2inst1
+      - DB2INST1_PASSWORD=db2inst1
+      - DBNAME=sample
+      - LICENSE=accept
+    ports:
+      - "50000:50000"
+    privileged: true


### PR DESCRIPTION
## Description

Add sample configuration and docker-compose setup for Db2. 
This PR accompanies the documentation update for the Db2 adapter, see https://github.com/scalar-labs/docs-internal-scalardb/pull/1345

## Related issues and/or PRs

N/A

## Changes made

Add configuration and docker-compose setup for Db2. 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
