### PR TITLE
Add TiDB and AlloyDB to ScalarDB core and ScalarDB Cluster samples

### DIFF
--- a/scalardb-cluster-standalone-mode/docker-compose.yaml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
     image: google/alloydbomni:16
     container_name: "alloydb-1"
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/scalardb-cluster-standalone-mode/docker-compose.yaml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yaml
@@ -67,6 +67,16 @@ services:
     command: >
       /bin/sh -c "az storage container create --name 'test-container' --connection-string 'DefaultEndpointsProtocol=http;AccountName=test;AccountKey=test;BlobEndpoint=http://blobstorage-1:10000/test;'"
 
+  alloydb:
+    image: google/alloydbomni:16
+    container_name: "alloydb-1"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_INITDB_ARGS: "--icu-locale=en-US-u-va-posix"
+
   scalardb-cluster-node:
     image: ghcr.io/scalar-labs/scalardb-cluster-node-byol-premium:3.17.0
     container_name: "scalardb-cluster-node"

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -53,16 +53,16 @@
 # scalar.db.password=test
 
 # For TiDB
-#scalar.db.storage=jdbc
-#scalar.db.contact_points=jdbc:mysql://host.docker.internal:4000/
-#scalar.db.username=root
-#scalar.db.password=
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:mysql://host.docker.internal:4000/
+# scalar.db.username=root
+# scalar.db.password=
 
 # For AlloyDB
-#scalar.db.storage=jdbc
-#scalar.db.contact_points=jdbc:postgresql://alloydb-1:5432/postgres
-#scalar.db.username=postgres
-#scalar.db.password=postgres
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:postgresql://alloydb-1:5432/
+# scalar.db.username=postgres
+# scalar.db.password=postgres
 
 # Standalone mode
 scalar.db.cluster.node.standalone_mode.enabled=true

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -52,6 +52,18 @@
 # scalar.db.username=test
 # scalar.db.password=test
 
+# For TiDB
+#scalar.db.storage=jdbc
+#scalar.db.contact_points=jdbc:mysql://host.docker.internal:4000/
+#scalar.db.username=root
+#scalar.db.password=
+
+# For AlloyDB
+#scalar.db.storage=jdbc
+#scalar.db.contact_points=jdbc:postgresql://alloydb-1:5432/postgres
+#scalar.db.username=postgres
+#scalar.db.password=postgres
+
 # Standalone mode
 scalar.db.cluster.node.standalone_mode.enabled=true
 

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -45,3 +45,15 @@
 # scalar.db.contact_points=jdbc:db2://localhost:50000/sample
 # scalar.db.username=db2inst1
 # scalar.db.password=db2inst1
+
+# For TiDB
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:mysql://localhost:4000/
+# scalar.db.username=root
+# scalar.db.password=
+
+# For AlloyDB
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:postgresql://localhost:5432/
+# scalar.db.username=postgres
+# scalar.db.password=postgres

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     image: google/alloydbomni:16
     container_name: "alloydb-1"
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -51,3 +51,12 @@ services:
     ports:
       - "50000:50000"
     privileged: true
+  alloydb:
+    image: google/alloydbomni:16
+    container_name: "alloydb-1"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_INITDB_ARGS: "--icu-locale=en-US-u-va-posix"


### PR DESCRIPTION
## Description

This adds TiDB and AlloyDB to ScalarDB core and ScalarDB Cluster samples.
Since TiDB is not started with Docker but using the `tiup` CLI, this does not add TiDB to the Docker compose files. 

> [!NOTE]  
> Please review this alongside this PR https://github.com/scalar-labs/docs-internal-scalardb/pull/1972 on the ScalarDB internal doc repository. 

## Related issues and/or PRs

N/A

## Changes made

- Add TiDB and AlloyDB basic configuration
- Add AlloyDB service to Docker compose files

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.
