### PR TITLE
Add sslMode=REQUIRED to MySQL JDBC URLs in samples

### DIFF
--- a/dotnet/microservice-transactions-sample-with-shared-cluster-with-linq/scalardb-cluster-node.properties
+++ b/dotnet/microservice-transactions-sample-with-shared-cluster-with-linq/scalardb-cluster-node.properties
@@ -9,7 +9,7 @@ scalar.db.multi_storage.storages.cassandra.password=cassandra
 
 # MySQL for the customer service tables
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 

--- a/microservice-transaction-sample-with-shared-cluster-with-jdbc/scalardb-cluster-node.properties
+++ b/microservice-transaction-sample-with-shared-cluster-with-jdbc/scalardb-cluster-node.properties
@@ -9,7 +9,7 @@ scalar.db.multi_storage.storages.cassandra.password=cassandra
 
 # MySQL for the customer service tables
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 

--- a/microservice-transaction-sample/customer-service/customer-service.properties
+++ b/microservice-transaction-sample/customer-service/customer-service.properties
@@ -9,7 +9,7 @@ scalar.db.multi_storage.storages.cassandra.password=cassandra
 
 # MySQL for the customer service tables
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 

--- a/microservice-transaction-sample/database-mysql.properties
+++ b/microservice-transaction-sample/database-mysql.properties
@@ -1,4 +1,4 @@
 scalar.db.storage=jdbc
-scalar.db.contact_points=jdbc:mysql://localhost:3306/
+scalar.db.contact_points=jdbc:mysql://localhost:3306/?sslMode=REQUIRED
 scalar.db.username=root
 scalar.db.password=mysql

--- a/multi-storage-transaction-sample/database.properties
+++ b/multi-storage-transaction-sample/database.properties
@@ -5,7 +5,7 @@ scalar.db.multi_storage.storages.cassandra.contact_points=localhost
 scalar.db.multi_storage.storages.cassandra.username=cassandra
 scalar.db.multi_storage.storages.cassandra.password=cassandra
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://localhost:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://localhost:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 scalar.db.multi_storage.namespace_mapping=customer:mysql,order:cassandra,coordinator:cassandra

--- a/scalardb-analytics-sample/config/scalardb.properties
+++ b/scalardb-analytics-sample/config/scalardb.properties
@@ -8,7 +8,7 @@ scalar.db.multi_storage.storages.cassandra.username=cassandra
 scalar.db.multi_storage.storages.cassandra.password=cassandra
 
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://scalardb-mysql:3306/sampledb
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://scalardb-mysql:3306/sampledb?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -1,6 +1,6 @@
 # For MySQL
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mysql://mysql-1:3306/
+# scalar.db.contact_points=jdbc:mysql://mysql-1:3306/?sslMode=REQUIRED
 # scalar.db.username=root
 # scalar.db.password=mysql
 

--- a/scalardb-kotlin-sample/database.properties
+++ b/scalardb-kotlin-sample/database.properties
@@ -1,6 +1,6 @@
 # For MySQL
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mysql://localhost:3306/
+# scalar.db.contact_points=jdbc:mysql://localhost:3306/?sslMode=REQUIRED
 # scalar.db.username=root
 # scalar.db.password=mysql
 

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -1,6 +1,6 @@
 # For MySQL
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mysql://localhost:3306/
+# scalar.db.contact_points=jdbc:mysql://localhost:3306/?sslMode=REQUIRED
 # scalar.db.username=root
 # scalar.db.password=mysql
 

--- a/spring-data-microservice-transaction-sample/scalardb-cluster-node-for-customer-service.properties
+++ b/spring-data-microservice-transaction-sample/scalardb-cluster-node-for-customer-service.properties
@@ -5,7 +5,7 @@ scalar.db.multi_storage.storages.cassandra.contact_points=cassandra-1
 scalar.db.multi_storage.storages.cassandra.username=cassandra
 scalar.db.multi_storage.storages.cassandra.password=cassandra
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql-1:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql-1:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 scalar.db.multi_storage.namespace_mapping=customer_service:mysql,coordinator:cassandra

--- a/spring-data-multi-storage-transaction-sample/scalardb-cluster-node.properties
+++ b/spring-data-multi-storage-transaction-sample/scalardb-cluster-node.properties
@@ -5,7 +5,7 @@ scalar.db.multi_storage.storages.cassandra.contact_points=cassandra-1
 scalar.db.multi_storage.storages.cassandra.username=cassandra
 scalar.db.multi_storage.storages.cassandra.password=cassandra
 scalar.db.multi_storage.storages.mysql.storage=jdbc
-scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql-1:3306/
+scalar.db.multi_storage.storages.mysql.contact_points=jdbc:mysql://mysql-1:3306/?sslMode=REQUIRED
 scalar.db.multi_storage.storages.mysql.username=root
 scalar.db.multi_storage.storages.mysql.password=mysql
 scalar.db.multi_storage.namespace_mapping=customer:mysql,order:cassandra,coordinator:cassandra


### PR DESCRIPTION
## Description

ScalarDB replaced MySQL Connector/J with MariaDB Connector/J in scalar-labs/scalardb#3428 to resolve a GPLv2 licensing concern. Unlike MySQL Connector/J, MariaDB Connector/J does not enable SSL by default. As a result, connecting to MySQL 8.0+ (which uses `caching_sha2_password` authentication by default) from the sample applications now fails with the following error:

```
RSA public key is not available client side (option serverRsaPublicKeyFile not set)
```

This PR fixes the MySQL JDBC URLs in the samples so that they continue to work after upgrading to a ScalarDB version that includes scalar-labs/scalardb#3428.

## Related issues and/or PRs

- scalar-labs/scalardb#3428

## Changes made

- Append `?sslMode=REQUIRED` to the MySQL JDBC URLs in the following sample configurations so that the connection is established over SSL, which allows `caching_sha2_password` authentication to work without requiring `allowPublicKeyRetrieval=true`. This matches the approach taken by the ScalarDB CI in scalar-labs/scalardb#3428.
  - `multi-storage-transaction-sample/database.properties`
  - `microservice-transaction-sample/database-mysql.properties`
  - `microservice-transaction-sample/customer-service/customer-service.properties`
  - `microservice-transaction-sample-with-shared-cluster-with-jdbc/scalardb-cluster-node.properties`
  - `spring-data-microservice-transaction-sample/scalardb-cluster-node-for-customer-service.properties`
  - `spring-data-multi-storage-transaction-sample/scalardb-cluster-node.properties`
  - `dotnet/microservice-transactions-sample-with-shared-cluster-with-linq/scalardb-cluster-node.properties`
  - `scalardb-analytics-sample/config/scalardb.properties`
- Also update the commented-out MySQL example URLs in the following files for consistency:
  - `scalardb-sample/database.properties`
  - `scalardb-kotlin-sample/database.properties`
  - `scalardb-cluster-standalone-mode/scalardb-cluster-node.properties`
- TiDB JDBC URLs (port 4000) are intentionally left unchanged because TiDB uses `mysql_native_password` by default and is not affected by this issue.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A