### PR TITLE
Add MariaDB, Sqlite, and Yugabyte to ScalarDB and ScalarDB Cluster Standalone samples

### DIFF
--- a/scalardb-cluster-standalone-mode/docker-compose.yml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     image: google/alloydbomni:16
     container_name: "alloydb-1"
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -110,13 +110,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3307:3306"
+      - "3306:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5434:5433"
+      - "5433:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte

--- a/scalardb-cluster-standalone-mode/docker-compose.yml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yml
@@ -110,13 +110,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3306:3306"
+      - "3307:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5433:5433"
+      - "5434:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte

--- a/scalardb-cluster-standalone-mode/docker-compose.yml
+++ b/scalardb-cluster-standalone-mode/docker-compose.yml
@@ -104,6 +104,23 @@ services:
         else
           /google/spanner/bin/spanner databases create test-db --database-dialect POSTGRESQL --deployment-endpoint $$ENDPOINT
         fi
+  mariadb:
+    image: mariadb:11.4
+    container_name: "mariadb-1"
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+    ports:
+      - "3306:3306"
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+  yugabyte:
+    image: yugabytedb/yugabyte:2025.2.2.2-b11
+    container_name: "yugabyte-1"
+    ports:
+      - "5433:5433"
+    environment:
+      YSQL_USER: yugabyte
+      YSQL_PASSWORD: yugabyte
+    command: bin/yugabyted start --background=false
 
   scalardb-cluster-node:
     image: ghcr.io/scalar-labs/scalardb-cluster-node-byol-premium:3.18.0

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -72,13 +72,13 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://mariadb-1:3306
+# scalar.db.contact_points=jdbc:mariadb://mariadb-1:3307
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://yugabyte-1:5433/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://yugabyte-1:5434/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte
 

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -72,13 +72,13 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://mariadb-1:3307
+# scalar.db.contact_points=jdbc:mariadb://mariadb-1:3306
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://yugabyte-1:5434/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://yugabyte-1:5433/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte
 

--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -70,6 +70,18 @@
 # scalar.db.username=
 # scalar.db.password=
 
+# For MariaDB
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:mariadb://mariadb-1:3306
+# scalar.db.username=root
+# scalar.db.password=mariadb
+
+# For Yugabyte
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:yugabytedb://yugabyte-1:5433/postgres
+# scalar.db.username=yugabyte
+# scalar.db.password=yugabyte
+
 # Standalone mode
 scalar.db.cluster.node.standalone_mode.enabled=true
 

--- a/scalardb-kotlin-sample/database.properties
+++ b/scalardb-kotlin-sample/database.properties
@@ -66,7 +66,7 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://localhost:3306
+# scalar.db.contact_points=jdbc:mariadb://localhost:3307
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
@@ -78,6 +78,6 @@
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5434/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte

--- a/scalardb-kotlin-sample/database.properties
+++ b/scalardb-kotlin-sample/database.properties
@@ -66,7 +66,7 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://localhost:3307
+# scalar.db.contact_points=jdbc:mariadb://localhost:3306
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
@@ -78,6 +78,6 @@
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://localhost:5434/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte

--- a/scalardb-kotlin-sample/database.properties
+++ b/scalardb-kotlin-sample/database.properties
@@ -63,3 +63,21 @@
 # scalar.db.contact_points=jdbc:cloudspanner://localhost:15000/databases/test-db;isExperimentalHost=true;usePlainText=true
 # scalar.db.username=
 # scalar.db.password=
+
+# For MariaDB
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:mariadb://localhost:3306
+# scalar.db.username=root
+# scalar.db.password=mariadb
+
+# For Sqlite
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:sqlite:scalardb-sample.sqlite3?busy_timeout=10000
+# scalar.db.username=
+# scalar.db.password=
+
+# For Yugabyte
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
+# scalar.db.username=yugabyte
+# scalar.db.password=yugabyte

--- a/scalardb-kotlin-sample/docker-compose.yml
+++ b/scalardb-kotlin-sample/docker-compose.yml
@@ -89,3 +89,20 @@ services:
         else
           /google/spanner/bin/spanner databases create test-db --database-dialect POSTGRESQL --deployment-endpoint $$ENDPOINT
         fi
+  mariadb:
+    image: mariadb:11.4
+    container_name: "mariadb-1"
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+    ports:
+      - "3306:3306"
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+  yugabyte:
+    image: yugabytedb/yugabyte:2025.2.2.2-b11
+    container_name: "yugabyte-1"
+    ports:
+      - "5433:5433"
+    environment:
+      YSQL_USER: yugabyte
+      YSQL_PASSWORD: yugabyte
+    command: bin/yugabyted start --background=false

--- a/scalardb-kotlin-sample/docker-compose.yml
+++ b/scalardb-kotlin-sample/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     image: google/alloydbomni:16
     container_name: "alloydb-1"
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -95,13 +95,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3307:3306"
+      - "3306:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5434:5433"
+      - "5433:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte

--- a/scalardb-kotlin-sample/docker-compose.yml
+++ b/scalardb-kotlin-sample/docker-compose.yml
@@ -95,13 +95,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3306:3306"
+      - "3307:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5433:5433"
+      - "5434:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -66,7 +66,7 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://localhost:3306
+# scalar.db.contact_points=jdbc:mariadb://localhost:3307
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
@@ -78,6 +78,6 @@
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5434/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -66,7 +66,7 @@
 
 # For MariaDB
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:mariadb://localhost:3307
+# scalar.db.contact_points=jdbc:mariadb://localhost:3306
 # scalar.db.username=root
 # scalar.db.password=mariadb
 
@@ -78,6 +78,6 @@
 
 # For Yugabyte
 # scalar.db.storage=jdbc
-# scalar.db.contact_points=jdbc:yugabytedb://localhost:5434/postgres
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
 # scalar.db.username=yugabyte
 # scalar.db.password=yugabyte

--- a/scalardb-sample/database.properties
+++ b/scalardb-sample/database.properties
@@ -63,3 +63,21 @@
 # scalar.db.contact_points=jdbc:cloudspanner://localhost:15000/databases/test-db;isExperimentalHost=true;usePlainText=true
 # scalar.db.username=
 # scalar.db.password=
+
+# For MariaDB
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:mariadb://localhost:3306
+# scalar.db.username=root
+# scalar.db.password=mariadb
+
+# For Sqlite
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:sqlite:scalardb-sample.sqlite3?busy_timeout=10000
+# scalar.db.username=
+# scalar.db.password=
+
+# For Yugabyte
+# scalar.db.storage=jdbc
+# scalar.db.contact_points=jdbc:yugabytedb://localhost:5433/postgres
+# scalar.db.username=yugabyte
+# scalar.db.password=yugabyte

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -89,3 +89,20 @@ services:
         else
           /google/spanner/bin/spanner databases create test-db --database-dialect POSTGRESQL --deployment-endpoint $$ENDPOINT
         fi
+  mariadb:
+    image: mariadb:11.4
+    container_name: "mariadb-1"
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+    ports:
+      - "3306:3306"
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+  yugabyte:
+    image: yugabytedb/yugabyte:2025.2.2.2-b11
+    container_name: "yugabyte-1"
+    ports:
+      - "5433:5433"
+    environment:
+      YSQL_USER: yugabyte
+      YSQL_PASSWORD: yugabyte
+    command: bin/yugabyted start --background=false

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     image: google/alloydbomni:16
     container_name: "alloydb-1"
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -95,13 +95,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3307:3306"
+      - "3306:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5434:5433"
+      - "5433:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte

--- a/scalardb-sample/docker-compose.yml
+++ b/scalardb-sample/docker-compose.yml
@@ -95,13 +95,13 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: mariadb
     ports:
-      - "3306:3306"
+      - "3307:3306"
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.2.2-b11
     container_name: "yugabyte-1"
     ports:
-      - "5433:5433"
+      - "5434:5433"
     environment:
       YSQL_USER: yugabyte
       YSQL_PASSWORD: yugabyte


### PR DESCRIPTION
## Description

This PR adds the configuration for several storages that were missing from the samples:
- Add MariaDB, Yugabyte, and SQLite to ScalarDB Java and Kotlin samples.
- Add MariaDB and Yugabyte to ScalarDB Cluster Standalone samples. However, SQLite is not added to ScalarDB Cluster Standalone sample because it would promote an anti-pattern; SQLite isn't designed for multi-process/multi-host access (single writer at a time, and its locking/WAL model assumes a single host), so it doesn't fit a Cluster deployment with several nodes.

## Related issues and/or PRs

- https://github.com/scalar-labs/scalardb-samples/pull/92

## Changes made

See the description.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

Preview of the changes: 

https://github.com/user-attachments/assets/bf063651-cd5c-4bb4-adc1-c32bed9d7dae


