### PR TITLE
Add S3 and GCS setup to standalone mode sample

### DIFF
--- a/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
+++ b/scalardb-cluster-standalone-mode/scalardb-cluster-node.properties
@@ -52,6 +52,18 @@
 # scalar.db.username=test
 # scalar.db.password=test
 
+# For Cloud Storage
+# scalar.db.storage=cloud-storage
+# scalar.db.contact_points=<CLOUD_STORAGE_BUCKET_NAME>
+# scalar.db.username=<GCP_PROJECT_ID>
+# scalar.db.password=<GCP_SERVICE_ACCOUNT_KEY_JSON>
+
+# For S3
+# scalar.db.storage=s3
+# scalar.db.contact_points=<REGION>/<S3_BUCKET_NAME>
+# scalar.db.username=<AWS_ACCESS_KEY>
+# scalar.db.password=<AWS_SECRET_ACCESS_KEY>
+
 # For TiDB
 # scalar.db.storage=jdbc
 # scalar.db.contact_points=jdbc:mysql://host.docker.internal:4000/


### PR DESCRIPTION
## Description

This PR adds S3 and GCS setup to the standalone mode sample. Those storages are newly covered by [this PR](https://github.com/scalar-labs/docs-internal-scalardb/pull/2548).

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-internal-scalardb/pull/2548

## Changes made

- Add configuration properties for S3 and GCS to `scalardb-cluster-standalone-mode/scalardb-cluster-node.properties`.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
